### PR TITLE
Move is_htmx -> __bool__

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,24 @@ The middleware does a few things:
 ``HtmxDetails``
 ^^^^^^^^^^^^^^^
 
-This class provides shortcuts for reading the HTMX-specific `request headers <https://htmx.org/reference/#request_headers>`__.
+This class provides shortcuts for reading the htmx-specific `request headers <https://htmx.org/reference/#request_headers>`__.
+
+``__bool__(): bool``
+~~~~~~~~~~~~~~~~~~~~
+
+``True`` if the request was made with htmx, otherwise ``False``.
+This is based on the presence of the ``HX-Request`` header.
+
+This allows you to switch behaviour for requests made with htmx like so:
+
+.. code-block:: python
+
+    def my_view(request):
+        if request.htmx:
+            template_name = "partial.html"
+        else:
+            template_name = "complete.html"
+        return render(template_name, ...)
 
 ``active_element: Optional[str]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,12 +113,6 @@ Based on the ``HX-Current-URL`` header.
 
 The ``id`` of the original event target element, or ``None``.
 Based on the ``HX-Event-Target`` header.
-
-``is_htmx: bool``
-~~~~~~~~~~~~~~~~~
-
-``True`` if the request was made with htmx, otherwise ``False``.
-This is based on the presence of the ``HX-Request`` header.
 
 ``prompt: Optional[str]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/django_htmx.py
+++ b/src/django_htmx.py
@@ -17,6 +17,9 @@ class HtmxDetails:
     def __init__(self, request):
         self.request = request
 
+    def __bool__(self):
+        return self.request.headers.get("HX-Request", "") == "true"
+
     @cached_property
     def active_element(self):
         return self.request.headers.get("HX-Active-Element") or None
@@ -36,10 +39,6 @@ class HtmxDetails:
     @cached_property
     def event_target(self):
         return self.request.headers.get("HX-Event-Target") or None
-
-    @cached_property
-    def is_htmx(self):
-        return self.request.headers.get("HX-Request", "") == "true"
 
     @cached_property
     def prompt(self):

--- a/tests/test_django_htmx.py
+++ b/tests/test_django_htmx.py
@@ -78,20 +78,20 @@ class HtmxMiddlewareTests(SimpleTestCase):
         self.middleware(request)
         assert request.htmx.event_target == "some-element"
 
-    def test_is_htmx_default(self):
+    def test_bool_default(self):
         request = self.request_factory.get("/")
         self.middleware(request)
-        assert request.htmx.is_htmx is False
+        assert bool(request.htmx) is False
 
-    def test_is_htmx_false(self):
+    def test_bool_false(self):
         request = self.request_factory.get("/", HTTP_HX_REQUEST="false")
         self.middleware(request)
-        assert request.htmx.is_htmx is False
+        assert bool(request.htmx) is False
 
-    def test_is_htmx_true(self):
+    def test_bool_true(self):
         request = self.request_factory.get("/", HTTP_HX_REQUEST="true")
         self.middleware(request)
-        assert request.htmx.is_htmx is True
+        assert bool(request.htmx) is True
 
     def test_prompt_default(self):
         request = self.request_factory.get("/")


### PR DESCRIPTION
A bit more Pythonic? Also shorter to write. `if request.htmx.is_htmx` read a bit confusingly.