### PR TITLE
Drop support for removed headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,35 +87,11 @@ This allows you to switch behaviour for requests made with htmx like so:
             template_name = "complete.html"
         return render(template_name, ...)
 
-``active_element: Optional[str]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``id`` of the active element if it exists, or ``None``.
-Based on the ``HX-Active-Element`` header.
-
-``active_element_name: Optional[str]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``name`` of the active element if it exists, or ``None``.
-Based on the ``HX-Active-Element-Name`` header.
-
-``active_element_value: Optional[str]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``value`` of the active element if it exists, or ``None``.
-Based on the ``HX-Active-Element-Value`` header.
-
 ``current_url: Optional[str]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The current URL of the browser, or ``None`` for non-htmx requests.
 Based on the ``HX-Current-URL`` header.
-
-``event_target: Optional[str]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``id`` of the original event target element, or ``None``.
-Based on the ``HX-Event-Target`` header.
 
 ``prompt: Optional[str]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/example/example/templates/attribute_test.html
+++ b/example/example/templates/attribute_test.html
@@ -15,24 +15,8 @@
       <td>{{ request.method }}</td>
     </tr>
     <tr>
-      <td><code>active_element</code></td>
-      <td>{{ request.htmx.active_element }}</td>
-    </tr>
-    <tr>
-      <td><code>active_element_name</code></td>
-      <td>{{ request.htmx.active_element_name }}</td>
-    </tr>
-    <tr>
-      <td><code>active_element_value</code></td>
-      <td>{{ request.htmx.active_element_value }}</td>
-    </tr>
-    <tr>
       <td><code>current_url</code></td>
       <td>{{ request.htmx.current_url }}</td>
-    </tr>
-    <tr>
-      <td><code>event_target</code></td>
-      <td>{{ request.htmx.event_target }}</td>
     </tr>
     <tr>
       <td><code>is_htmx</code></td>

--- a/src/django_htmx.py
+++ b/src/django_htmx.py
@@ -21,24 +21,8 @@ class HtmxDetails:
         return self.request.headers.get("HX-Request", "") == "true"
 
     @cached_property
-    def active_element(self):
-        return self.request.headers.get("HX-Active-Element") or None
-
-    @cached_property
-    def active_element_name(self):
-        return self.request.headers.get("HX-Active-Element-Name") or None
-
-    @cached_property
-    def active_element_value(self):
-        return self.request.headers.get("HX-Active-Element-Value") or None
-
-    @cached_property
     def current_url(self):
         return self.request.headers.get("HX-Current-URL") or None
-
-    @cached_property
-    def event_target(self):
-        return self.request.headers.get("HX-Event-Target") or None
 
     @cached_property
     def prompt(self):

--- a/tests/test_django_htmx.py
+++ b/tests/test_django_htmx.py
@@ -22,40 +22,6 @@ class HtmxMiddlewareTests(SimpleTestCase):
         self.middleware(request)
         assert request.method == "DELETE"
 
-    def test_active_element_default(self):
-        request = self.request_factory.get("/")
-        self.middleware(request)
-        assert request.htmx.active_element is None
-
-    def test_active_element_set(self):
-        request = self.request_factory.get("/", HTTP_HX_ACTIVE_ELEMENT="some-element")
-        self.middleware(request)
-        assert request.htmx.active_element == "some-element"
-
-    def test_active_element_name_default(self):
-        request = self.request_factory.get("/")
-        self.middleware(request)
-        assert request.htmx.active_element_name is None
-
-    def test_active_element_name_set(self):
-        request = self.request_factory.get(
-            "/", HTTP_HX_ACTIVE_ELEMENT_NAME="some-element-name"
-        )
-        self.middleware(request)
-        assert request.htmx.active_element_name == "some-element-name"
-
-    def test_active_element_value_default(self):
-        request = self.request_factory.get("/")
-        self.middleware(request)
-        assert request.htmx.active_element_value is None
-
-    def test_active_element_value_set(self):
-        request = self.request_factory.get(
-            "/", HTTP_HX_ACTIVE_ELEMENT_VALUE="some-element-value"
-        )
-        self.middleware(request)
-        assert request.htmx.active_element_value == "some-element-value"
-
     def test_current_url_default(self):
         request = self.request_factory.get("/")
         self.middleware(request)
@@ -67,16 +33,6 @@ class HtmxMiddlewareTests(SimpleTestCase):
         )
         self.middleware(request)
         assert request.htmx.current_url == "https://example.com"
-
-    def test_event_target_default(self):
-        request = self.request_factory.get("/")
-        self.middleware(request)
-        assert request.htmx.event_target is None
-
-    def test_event_target_set(self):
-        request = self.request_factory.get("/", HTTP_HX_EVENT_TARGET="some-element")
-        self.middleware(request)
-        assert request.htmx.event_target == "some-element"
 
     def test_bool_default(self):
         request = self.request_factory.get("/")


### PR DESCRIPTION
Drop support for these headers as they were removed in [htmx 1.1.0](https://htmx.org/posts/2021-1-6-htmx-1.1.0-is-released/): HX-Event-Target, HX-Active-Element, HX-Active-Element-Name, HX-Active-Element-Value