### PR TITLE
Add partial rendering example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ Installation
            ...,
        ]
 
+Example app
+-----------
+
+See the `example app <https://github.com/adamchainz/django-htmx/tree/main/example>`__ in the ``example/`` directory of the GitHub repository for usage of django-htmx.
+
 API
 ---
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,14 +1,17 @@
 Example Application
 ===================
 
-Use Python 3.8 to run, with vanilla venv, pip, and Django:
+Use Python 3.8 to set up and run with these commands:
 
 .. code-block:: sh
 
    python -m venv venv
    source venv/bin/activate
-   python -m pip install -U pip -r requirements.txt -e ..
+   python -m pip install -U pip
+   python -m pip install -r requirements.txt -e ..
    DEBUG=1 python manage.py runserver
 
 Open it at http://127.0.0.1:8000/ .
-From there you can test some htmx features which use django-htmx.
+
+Browse the individual examples.
+Take them apart in your browser’s network tab and read the commented source code to see what’s going on!

--- a/example/example/core/views.py
+++ b/example/example/core/views.py
@@ -1,13 +1,24 @@
 import time
+from dataclasses import dataclass
 
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
+from faker import Faker
 
 
+@require_http_methods(("GET",))
 def index(request):
     return render(request, "index.html")
 
 
+# Middleware tester
+
+# This uses two views - one to render the form, and the second to render the
+# table of attributes.
+
+
+@require_http_methods(("GET",))
 def middleware_tester(request):
     return render(request, "middleware-tester.html")
 
@@ -17,7 +28,46 @@ def middleware_tester_table(request):
     return render(
         request,
         "middleware-tester-table.html",
+        {"timestamp": time.time()},
+    )
+
+
+# Partial rendering example
+
+
+# This dataclass acts as a stand-in for a database model - the example app
+# avoids having a database for simplicity.
+
+
+@dataclass
+class Person:
+    id: int
+    name: str
+
+
+faker = Faker()
+people = [Person(id=i, name=faker.name()) for i in range(1, 235)]
+
+
+@require_http_methods(("GET",))
+def partial_rendering(request):
+    # Standard Django pagination
+    page_num = request.GET.get("page", "1")
+    page = Paginator(object_list=people, per_page=10).get_page(page_num)
+
+    # The htmx magic - use a different, minimal base template for htmx
+    # requests, allowing us to skip rendering the unchanging parts of the
+    # template.
+    if request.htmx:
+        base_template = "_partial.html"
+    else:
+        base_template = "_base.html"
+
+    return render(
+        request,
+        "partial-rendering.html",
         {
-            "timestamp": time.time(),
+            "base_template": base_template,
+            "page": page,
         },
     )

--- a/example/example/templates/_base.html
+++ b/example/example/templates/_base.html
@@ -4,19 +4,30 @@
   <meta charset="utf-8">
   <title>django-htmx example app</title>
   <link rel="stylesheet" href="/static/mvp.css">
+
+  <!-- An example of how we can configure htmx -->
+  <!-- https://htmx.org/docs/#config -->
+  <meta name="htmx-config" content='{"historyCacheSize": 15}'>
 </head>
 <body>
   <header>
     <nav>
-      <h1>django-htmx example app</h1>
+      <h1>
+        <a href="/">
+          django-htmx example app
+        </a>
+      </h1>
       <ul>
         <li>
           <a href="/middleware-tester/">Middleware Tester</a>
         </li>
+        <li>
+          <a href="/partial-rendering/">Partial Rendering</a>
+        </li>
       </ul>
     </nav>
   </header>
-  <main>
+  <main id="main">
     {% block main %}{% endblock %}
   </main>
   <footer>

--- a/example/example/templates/_partial.html
+++ b/example/example/templates/_partial.html
@@ -1,0 +1,3 @@
+<main id="main">
+  {% block main %}{% endblock %}
+</main>

--- a/example/example/templates/partial-rendering.html
+++ b/example/example/templates/partial-rendering.html
@@ -1,0 +1,80 @@
+{% extends base_template %}
+
+{% block main %}
+  <section>
+    <p>
+      This example shows using <a href="https://htmx.org/attributes/hx-boost/">the <code>hx-boost</code> feature</a> to make page requests using AJAX.
+      The view does partial rendering for requests made with htmx, using an alternative base template that only renders the <code>#main</code> element, saving time and bandwidth.
+      Paginate through the below list of randomly generated people to see this in action.
+    </p>
+  </section>
+
+  <section>
+    <table>
+      <thead>
+        <tr>
+          <th>id</th>
+          <th>name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for person in page.object_list %}
+          <tr>
+            <td>{{ person.id }}</td>
+            <td>{{ person.name }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="2">
+              No people on this page.
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <!--
+      The htmx attributes set on the nav are inherited by the child links.
+      hx-boost tells htmx to convert the plain links into AJAX requests.
+      hx-target + hx-swap tell it how to swap the partially renderede page into
+      the DOM.
+    -->
+    <nav hx-boost="true" hx-target="#main" hx-swap="outerHTML">
+      <ul>
+        {% if page.number != 1 %}
+          <li>
+            <a href="?page=1">
+              &laquo; First
+            </a>
+          </li>
+        {% endif %}
+        {% if page.has_previous %}
+          <li>
+            <a href="?page={{ page.previous_page_number }}">
+              {{ page.previous_page_number }}
+            </a>
+          </li>
+        {% endif %}
+        <li>
+          {{ page.number }}
+        </li>
+        {% if page.has_next %}
+          <li>
+            <a href="?page={{ page.next_page_number }}">
+              {{ page.next_page_number }}
+            </a>
+          </li>
+        {% endif %}
+        {% if page.number != page.paginator.num_pages %}
+          <li>
+            <a href="?page={{ page.paginator.num_pages }}">
+              &raquo; Last
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    </nav>
+  </section>
+{% endblock %}

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,9 +1,15 @@
 from django.urls import path
 
-from example.core.views import index, middleware_tester, middleware_tester_table
+from example.core.views import (
+    index,
+    middleware_tester,
+    middleware_tester_table,
+    partial_rendering,
+)
 
 urlpatterns = [
     path("", index),
     path("middleware-tester/", middleware_tester),
     path("middleware-tester/table/", middleware_tester_table),
+    path("partial-rendering/", partial_rendering),
 ]

--- a/example/requirements.in
+++ b/example/requirements.in
@@ -1,1 +1,2 @@
 django
+faker

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -4,7 +4,19 @@
 #
 #    pip-compile
 #
-asgiref==3.2.10           # via django
-django==3.1.2             # via -r requirements.in
-pytz==2020.1              # via django
-sqlparse==0.4.1           # via django
+asgiref==3.2.10
+    # via django
+django==3.1.2
+    # via -r requirements.in
+faker==6.0.0
+    # via -r requirements.in
+python-dateutil==2.8.1
+    # via faker
+pytz==2020.1
+    # via django
+six==1.15.0
+    # via python-dateutil
+sqlparse==0.4.1
+    # via django
+text-unidecode==1.3
+    # via faker


### PR DESCRIPTION
This takes a slightly different approach to the mixin-based one in #5 that doesn't need any new features in django-htmx.

By using Django's ability to dynamically select a base template in `{% extends %}`, we avoid a need for `{% htmx_include %}`.

By using the inheritance of htmx attributes, we avoid the need for the `htmx_attrs` tag to repeat common attributes.