### PR TITLE
Add example form with CSRF token handling

### DIFF
--- a/example/example/core/forms.py
+++ b/example/example/core/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class OddNumberForm(forms.Form):
+    number = forms.IntegerField()

--- a/example/example/core/views.py
+++ b/example/example/core/views.py
@@ -6,10 +6,35 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from faker import Faker
 
+from example.core.forms import OddNumberForm
+
 
 @require_http_methods(("GET",))
 def index(request):
     return render(request, "index.html")
+
+
+# CSRF Demo
+
+
+@require_http_methods(("GET",))
+def csrf_demo(request):
+    return render(request, "csrf-demo.html")
+
+
+@require_http_methods(("POST",))
+def csrf_demo_checker(request):
+    form = OddNumberForm(request.POST)
+    if form.is_valid():
+        number = form.cleaned_data["number"]
+        number_is_odd = number % 2 == 1
+    else:
+        number_is_odd = False
+    return render(
+        request,
+        "csrf-demo-checker.html",
+        {"form": form, "number_is_odd": number_is_odd},
+    )
 
 
 # Middleware tester

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -16,6 +16,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
 ]
 

--- a/example/example/templates/_base.html
+++ b/example/example/templates/_base.html
@@ -19,6 +19,9 @@
       </h1>
       <ul>
         <li>
+          <a href="/csrf-demo/">CSRF Demo</a>
+        </li>
+        <li>
           <a href="/middleware-tester/">Middleware Tester</a>
         </li>
         <li>

--- a/example/example/templates/csrf-demo-checker.html
+++ b/example/example/templates/csrf-demo-checker.html
@@ -1,0 +1,7 @@
+{% if not form.is_valid %}
+  Please enter a number
+{% elif number_is_odd %}
+  {{ form.number.value }} is odd!
+{% else %}
+  {{ form.number.value }} is not odd.
+{% endif %}

--- a/example/example/templates/csrf-demo.html
+++ b/example/example/templates/csrf-demo.html
@@ -1,0 +1,39 @@
+{% extends "_base.html" %}
+
+{% block main %}
+  <section>
+    <p>
+      This form shows you how to implement CSRF with htmx, using <a href="https://dev.htmx.org/attributes/hx-headers/"> the<code>hx-headers</code> attribute</a>.
+    </p>
+  </section>
+  <section>
+    <!--
+      Note you can place the hx-headers attribute on your <body> tag so it
+      affects all requests, reducing repetition.
+
+      The header name may be changed with the CSRF_HEADER_NAME setting;
+      https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-CSRF_HEADER_NAME
+
+      Note we use {{ csrf_token }} instead of {% csrf_token %} to get the
+      variable rather than a rendered HTML <input>.
+    -->
+    <form hx-post="/csrf-demo/checker/"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+          hx-target="#result">
+      <label for="id_number">
+        Number:
+      </label>
+      <input id="id_number"
+             name="number"
+             type="text"
+             placeholder=""></input>
+      <button type="submit">
+        Check if odd
+      </button>
+    </p>
+    </form>
+  </section>
+  <section>
+    <p id="result"><em>Awaiting interaction...</em></p>
+  </section>
+{% endblock %}

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
 from example.core.views import (
-    index,
     csrf_demo,
     csrf_demo_checker,
+    index,
     middleware_tester,
     middleware_tester_table,
     partial_rendering,

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from example.core.views import (
     index,
+    csrf_demo,
+    csrf_demo_checker,
     middleware_tester,
     middleware_tester_table,
     partial_rendering,
@@ -9,6 +11,8 @@ from example.core.views import (
 
 urlpatterns = [
     path("", index),
+    path("csrf-demo/", csrf_demo),
+    path("csrf-demo/checker/", csrf_demo_checker),
     path("middleware-tester/", middleware_tester),
     path("middleware-tester/table/", middleware_tester_table),
     path("partial-rendering/", partial_rendering),


### PR DESCRIPTION
hx-headers to the rescue.