### PR TITLE
Add support for the HX-Boosted header

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 History
 =======
 
+* Support the ``HX-Boosted`` header, which was added in htmx 1.6.0.
+  This is parsed into the ``request.htmx.boosted`` attribute.
+
 1.3.0 (2021-09-28)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -200,9 +200,10 @@ The deserialized JSON representtation of the event that triggered the request if
 This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
 
 ``boosted: bool``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
-``True`` if the request request came from an element with hx-boost attribute. Based on the ``HX-Boosted`` header.
+``True`` if the request request came from an element with the ``hx-boost`` attribute.
+Based on the ``HX-Boosted`` header.
 
 ``django_htmx.http.HttpResponseStopPolling: type[HttpResponse]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,12 @@ This allows you to switch behaviour for requests made with htmx like so:
             template_name = "complete.html"
         return render(template_name, ...)
 
+``boosted: bool``
+~~~~~~~~~~~~~~~~~
+
+``True`` if the request request came from an element with the ``hx-boost`` attribute.
+Based on the ``HX-Boosted`` header.
+
 ``current_url: str | None``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -198,12 +204,6 @@ Based on the ``HX-Trigger-Name`` header.
 
 The deserialized JSON representtation of the event that triggered the request if it exists, or ``None``.
 This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
-
-``boosted: bool``
-~~~~~~~~~~~~~~~~~
-
-``True`` if the request request came from an element with the ``hx-boost`` attribute.
-Based on the ``HX-Boosted`` header.
 
 ``django_htmx.http.HttpResponseStopPolling: type[HttpResponse]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,11 @@ Based on the ``HX-Trigger-Name`` header.
 The deserialized JSON representtation of the event that triggered the request if it exists, or ``None``.
 This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
 
+``boosted: bool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``True`` if the request request came from an element with hx-boost attribute. Based on the ``HX-Boosted`` header.
+
 ``django_htmx.http.HttpResponseStopPolling: type[HttpResponse]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -62,3 +62,7 @@ class HtmxDetails:
             except json.JSONDecodeError:
                 value = None
         return value
+
+    @cached_property
+    def boosted(self) -> bool:
+        return self._get_header_value("HX-Boosted") == "true"

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -30,6 +30,10 @@ class HtmxDetails:
         return self._get_header_value("HX-Request") == "true"
 
     @cached_property
+    def boosted(self) -> bool:
+        return self._get_header_value("HX-Boosted") == "true"
+
+    @cached_property
     def current_url(self) -> Optional[str]:
         return self._get_header_value("HX-Current-URL")
 
@@ -62,7 +66,3 @@ class HtmxDetails:
             except json.JSONDecodeError:
                 value = None
         return value
-
-    @cached_property
-    def boosted(self) -> bool:
-        return self._get_header_value("HX-Boosted") == "true"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -27,6 +27,16 @@ class HtmxMiddlewareTests(SimpleTestCase):
         self.middleware(request)
         assert bool(request.htmx) is True
 
+    def test_boosted_default(self):
+        request = self.request_factory.get("/")
+        self.middleware(request)
+        assert not request.htmx.boosted
+
+    def test_boosted_set(self):
+        request = self.request_factory.get("/", HTTP_HX_BOOSTED="true")
+        self.middleware(request)
+        assert request.htmx.boosted
+
     def test_current_url_default(self):
         request = self.request_factory.get("/")
         self.middleware(request)
@@ -116,13 +126,3 @@ class HtmxMiddlewareTests(SimpleTestCase):
         )
         self.middleware(request)
         assert request.htmx.triggering_event == {"target": None}
-
-    def test_boosted_default(self):
-        request = self.request_factory.get("/")
-        self.middleware(request)
-        assert not request.htmx.boosted
-
-    def test_boosted_set(self):
-        request = self.request_factory.get("/", HTTP_HX_BOOSTED="true")
-        self.middleware(request)
-        assert request.htmx.boosted

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -116,3 +116,13 @@ class HtmxMiddlewareTests(SimpleTestCase):
         )
         self.middleware(request)
         assert request.htmx.triggering_event == {"target": None}
+
+    def test_boosted_default(self):
+        request = self.request_factory.get("/")
+        self.middleware(request)
+        assert not request.htmx.boosted
+
+    def test_boosted_set(self):
+        request = self.request_factory.get("/", HTTP_HX_BOOSTED="true")
+        self.middleware(request)
+        assert request.htmx.boosted


### PR DESCRIPTION
Add the property 'boosted' to HtmxDetails to support the new header HX-Boosted
that was added in htmx 1.6.0

