### PR TITLE
Add `HttpResponseLocation` to send response with `HX-Location`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ History
 
 * Add ``django_htmx.http.retarget()`` for setting the ``HX-Retarget`` header added in `htmx 1.6.1 <https://htmx.org/posts/2021-11-22-htmx-1.6.1-is-released/>`__.
 
+* Add ``HttpResponseLocation`` for sending a response with the ``HX-Location`` header.
+
+  Thanks to Ben Beecher in `PR #239 <https://github.com/adamchainz/django-htmx/pull/239>`__.
+
 1.12.2 (2022-08-31)
 -------------------
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -3,6 +3,9 @@ HTTP
 
 .. currentmodule:: django_htmx.http
 
+Response classes
+----------------
+
 .. autoclass:: HttpResponseClientRedirect
 
    htmx can trigger a client side redirect when it receives a response with the |HX-Redirect header|__.
@@ -44,6 +47,34 @@ HTTP
                return HttpResponseClientRefresh()
            ...
 
+.. autoclass:: HttpResponseLocation
+
+   An HTTP response class for sending the |HX-Location header|__.
+   This header makes htmx make a client-side “boosted” request, acting like a client side redirect with a page reload.
+
+   .. |HX-Location header| replace:: ``HX-Location`` header
+   __ https://htmx.org/headers/hx-location/
+
+   ``redirect_to`` should be the URL to redirect to, as per Django’s |HttpResponseRedirect|__.
+
+   .. |HttpResponseRedirect| replace:: ``HttpResponseRedirect``
+   __ https://docs.djangoproject.com/en/stable/ref/request-response/#django.http.HttpResponseRedirect
+
+   ``source``, ``event``, ``target``, ``swap``, ``values``, and ``headers`` are all optional, with meaning as `documented by htmx <https://htmx.org/headers/hx-location/>`__.
+
+   For example:
+
+   .. code-block:: python
+
+        from django_htmx.http import HttpResponseLocation
+
+
+        def wait_for_completion(request, action_id):
+            ...
+            if action.completed:
+                return HttpResponseLocation(f"/action/{action.id}/completed/")
+            ...
+
 .. autoclass:: HttpResponseStopPolling
 
    When using a `polling trigger <https://htmx.org/docs/#polling>`__, htmx will stop polling when it encounters a response with the special HTTP status code 286.
@@ -79,6 +110,9 @@ HTTP
            if event_finished():
                return render("event-finished.html", status=HTMX_STOP_POLLING)
            ...
+
+Response modifying functions
+----------------------------
 
 .. autofunction:: push_url
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -93,6 +93,19 @@ def retarget(response: _HttpResponse, target: str) -> _HttpResponse:
     return response
 
 
+def set_location(
+    response: HttpResponseBase,
+    path: str,
+    spec: dict[str, Any] | None = None,
+) -> HttpResponseBase:
+
+    if spec:
+        path = json.dumps({"path": path, **spec}, cls=DjangoJSONEncoder)
+
+    response["HX-Location"] = path
+    return response
+
+
 def trigger_client_event(
     response: _HttpResponse,
     name: str,
@@ -125,17 +138,4 @@ def trigger_client_event(
 
     response[header] = json.dumps(data, cls=DjangoJSONEncoder)
 
-    return response
-
-
-def set_location(
-    response: HttpResponseBase,
-    path: str,
-    spec: dict[str, Any] | None = None,
-) -> HttpResponseBase:
-
-    if spec:
-        path = json.dumps({"path": path, **spec}, cls=DjangoJSONEncoder)
-
-    response["HX-Location"] = path
     return response

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -94,10 +94,10 @@ def retarget(response: _HttpResponse, target: str) -> _HttpResponse:
 
 
 def set_location(
-    response: HttpResponseBase,
+    response: _HttpResponse,
     path: str,
     spec: dict[str, Any] | None = None,
-) -> HttpResponseBase:
+) -> _HttpResponse:
 
     if spec:
         path = json.dumps({"path": path, **spec}, cls=DjangoJSONEncoder)

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -29,6 +29,32 @@ class HttpResponseStopPolling(HttpResponse):
         self._reason_phrase = "Stop Polling"
 
 
+class HttpResponseLocation(HttpResponseRedirectBase):
+    status_code = 200
+    swap_spec_kwargs = (
+        "source",
+        "event",
+        "handler",
+        "target",
+        "swap",
+        "values",
+        "headers",
+    )
+
+    def __init__(self, redirect_to: str, *args: Any, **kwargs: Any) -> None:
+        swap_details = {}
+        for key in self.swap_spec_kwargs:
+            if key in kwargs:
+                swap_details[key] = kwargs.pop(key)
+
+        super().__init__(redirect_to, *args, **kwargs)
+
+        swap_details["path"] = self["Location"]
+        swap_spec = json.dumps(swap_details)
+        self["HX-Location"] = swap_spec
+        del self["Location"]
+
+
 class HttpResponseClientRedirect(HttpResponseRedirectBase):
     status_code = 200
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -135,10 +135,7 @@ def set_location(
 ) -> HttpResponseBase:
 
     if spec:
-        try:
-            path = json.dumps({"path": path, **spec}, cls=DjangoJSONEncoder)
-        except json.JSONDecodeError as exc:
-            raise ValueError("Swap Spec parameters should be JSON Encodable.") from exc
-    response["HX-Location"] = path
+        path = json.dumps({"path": path, **spec}, cls=DjangoJSONEncoder)
 
+    response["HX-Location"] = path
     return response

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -15,6 +15,7 @@ from django_htmx.http import HttpResponseStopPolling
 from django_htmx.http import push_url
 from django_htmx.http import reswap
 from django_htmx.http import retarget
+from django_htmx.http import set_location
 from django_htmx.http import trigger_client_event
 
 
@@ -45,7 +46,9 @@ class HttpResponseClientRedirectTests(SimpleTestCase):
 
 class HttpResponseLocationTests(SimpleTestCase):
     def test_success(self):
-        response = HttpResponseLocation("https://example.com", target="#sample")
+        response = HttpResponseLocation(
+            "https://example.com", spec={"target": "#sample"}
+        )
 
         assert response.status_code == 200
         assert "Location" not in response
@@ -211,3 +214,26 @@ class TriggerClientEventTests(SimpleTestCase):
             response["HX-Trigger"]
             == '{"showMessage": {"uuid": "12345678-1234-5678-1234-567812345678"}}'
         )
+
+
+class SetLocationTests(SimpleTestCase):
+    def test_simple_success(self):
+        response = HttpResponse()
+
+        result = set_location(response, path="https://example.com")
+
+        assert result is response
+        assert response["HX-Location"] == "https://example.com"
+
+    def test_swap_spec_success(self):
+        response = HttpResponse()
+
+        result = set_location(
+            response,
+            path="https://example.com",
+            spec={"target": "#mydiv"},
+        )
+
+        assert result is response
+        swap_spec = json.loads(response["HX-location"])
+        assert swap_spec == {"path": "https://example.com", "target": "#mydiv"}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from uuid import UUID
 
 import pytest
@@ -9,6 +10,7 @@ from django.test import SimpleTestCase
 
 from django_htmx.http import HttpResponseClientRedirect
 from django_htmx.http import HttpResponseClientRefresh
+from django_htmx.http import HttpResponseLocation
 from django_htmx.http import HttpResponseStopPolling
 from django_htmx.http import push_url
 from django_htmx.http import reswap
@@ -39,6 +41,16 @@ class HttpResponseClientRedirectTests(SimpleTestCase):
             '<HttpResponseClientRedirect status_code=200, "text/html; '
             + 'charset=utf-8", url="https://example.com">'
         )
+
+
+class HttpResponseLocationTests(SimpleTestCase):
+    def test_success(self):
+        response = HttpResponseLocation("https://example.com", target="#sample")
+
+        assert response.status_code == 200
+        assert "Location" not in response
+        swap_spec = json.loads(response["HX-location"])
+        assert swap_spec == {"path": "https://example.com", "target": "#sample"}
 
 
 class HttpResponseClientRefreshTests(SimpleTestCase):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -51,9 +51,7 @@ class HttpResponseLocationTests(SimpleTestCase):
         )
 
         assert response.status_code == 200
-        # django-stubs missing HttpResponseBase.__contains__ until:
-        # https://github.com/typeddjango/django-stubs/pull/1099
-        assert "Location" not in response  # type: ignore [operator]
+        assert "Location" not in response
         swap_spec = json.loads(response["HX-location"])
         assert swap_spec == {"path": "https://example.com", "target": "#sample"}
 


### PR DESCRIPTION
Adding a new http response to use client side redirects:  https://github.com/bigskysoftware/htmx/pull/832

I think the most common pattern is: 

Form fails validation, needs to be loaded in the same location as it was previously displayed OR it's successful and then you want to redirect on the client side without destroying client side state.