### PR TITLE
Add multiple template render support

### DIFF
--- a/src/template.py
+++ b/src/template.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+from django.template.loader import render_to_string
+
+
+def render_multiple(
+    request: HttpRequest, template_names: list[str], context: dict[str, Any]
+) -> HttpResponse:
+    rendered_html = ""
+    for template_name in template_names:
+        rendered_html += render_to_string(
+            template_name, context=context, request=request
+        )
+
+    return HttpResponse(rendered_html)


### PR DESCRIPTION
After extensive use of HTMX and Django I found the need to have a multiple render template system. This is because i'm creating more and more partials (small template with a specific purpose).

What is good about this new feature is that you can string together multiple templates, provide one long context, and send it to the frontend for HTMX to pickup the combined HTML.

This is very powerful when you use it in conjunction with hx-swap-oob. This way you can easily update multiple parts of the page with one big and concise request.

This make the backend very flexible and customizable.