### PR TITLE
Fix `HttpResponseClientRedirect` not overriding `url` property

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Override ``HttpResponseClientRedirect.url`` property to fix ``HttpResponseClientRedirect.__repr__``.
+
 1.12.0 (2022-06-05)
 -------------------
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -34,7 +34,9 @@ class HttpResponseClientRedirect(HttpResponseRedirectBase):
         self["HX-Redirect"] = self["Location"]
         del self["Location"]
 
-    url = property(lambda self: self["HX-Redirect"])
+    @property
+    def url(self) -> str:
+        return self["HX-Redirect"]
 
 
 class HttpResponseClientRefresh(HttpResponse):

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -34,6 +34,8 @@ class HttpResponseClientRedirect(HttpResponseRedirectBase):
         self["HX-Redirect"] = self["Location"]
         del self["Location"]
 
+    url = property(lambda self: self["HX-Redirect"])
+
 
 class HttpResponseClientRefresh(HttpResponse):
     def __init__(self) -> None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -30,6 +30,14 @@ class HttpResponseClientRedirectTests(SimpleTestCase):
         assert response["HX-Redirect"] == "https://example.com"
         assert "Location" not in response
 
+    def test_repr(self):
+        response = HttpResponseClientRedirect("https://example.com")
+
+        assert repr(response) == (
+            '<HttpResponseClientRedirect status_code=200, "text/html; '
+            + 'charset=utf-8", url="https://example.com">'
+        )
+
 
 class HttpResponseClientRefreshTests(SimpleTestCase):
     def test_success(self):


### PR DESCRIPTION
The `url` property is used in the base class's `__repr__` method using
the `Location` header that has been deleted, so it throws a `KeyError`. 