### PR TITLE
Make params argument of trigger_client_event() optional

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Make the ``params`` argument of ``trigger_client_event()`` optional.
+
+  Thanks to Chris Tapper in `PR #263 <https://github.com/adamchainz/django-htmx/pull/263>`__.
+
 * Add ``django_htmx.http.push_url()`` for setting the browser location.
 
   Thanks to Chris Tapper in `PR #264 <https://github.com/adamchainz/django-htmx/pull/264>`__.

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -93,7 +93,7 @@ HTTP
 .. autofunction:: trigger_client_event
 
    Modify the |HX-Trigger headers|__ of ``response`` to trigger client-side events, and return the response.
-   Takes the name of the event to trigger and any JSON-compatible parameters for it, and stores them in the appropriate header. Uses |DjangoJSONEncoder|__ for its extended data type support.
+   Takes the name of the event to trigger and (optionally) any JSON-compatible parameters for it, and stores them in the appropriate header. Uses |DjangoJSONEncoder|__ for its extended data type support.
 
    .. |HX-Trigger headers| replace:: ``HX-Trigger`` headers
    __ https://htmx.org/headers/hx-trigger/

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -57,10 +57,12 @@ def push_url(response: _R, url: str | Literal[False]) -> _R:
 def trigger_client_event(
     response: _R,
     name: str,
-    params: dict[str, Any],
+    params: dict[str, Any] | None = None,
     *,
     after: EventAfterType = "receive",
 ) -> _R:
+    params = params or {}
+
     if after == "receive":
         header = "HX-Trigger"
     elif after == "settle":

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -104,6 +104,14 @@ class TriggerClientEventTests(SimpleTestCase):
             response["HX-Trigger"] == '{"showConfetti": {"colours": ["purple", "red"]}}'
         )
 
+    def test_success_no_params(self):
+        response = HttpResponse()
+
+        result = trigger_client_event(response, "showConfetti")
+
+        assert result is response
+        assert response["HX-Trigger"] == '{"showConfetti": {}}'
+
     def test_success_streaming(self):
         response = StreamingHttpResponse(iter((b"hello",)))
 


### PR DESCRIPTION
This PR adds support for triggering a client event with no params without having to call the `trigger_client_event` with a `params` argument. It also adds support for using string rather than JSON value for the `HX-Trigger*` when there is only a single event with no params (see https://htmx.org/headers/hx-trigger/).

```python
# Before this PR
>>> response = HttpResponse()
>>> response = trigger_client_event(response, "showConfetti", {})
>>> response.headers["HX-Trigger"]
'{"showConfetti": {}}'

# After this PR
>>> response = HttpResponse()
>>> response = trigger_client_event(response, "showConfetti")
>>> response.headers["HX-Trigger"]
"showConfetti"

# Also handles promoting of single events to JSON if additional events are added
>>> response = HttpResponse()
>>> response = trigger_client_event(response, "showConfetti")
>>> response.headers["HX-Trigger"]
"showConfetti"
>>> response = trigger_client_event(response, "showMessage", {"value": "Hello!"})
>>> response.headers["HX-Trigger"]
'{"showConfetti": {}, "showMessage": {"value": "Hello!"}}'
```

I chose to set the default value of promoted events to `{}` rather than `None` (or something else), as this mirrors how HTMX itself handles events with no params (it sets the details to an empty object; see https://github.com/bigskysoftware/htmx/blob/60acaacc416812e85245f8e00d1e8bc4954d1d83/src/htmx.js#L992-L1008)

I realise that the docs will also need to be updated - I'm happy to do this as well, but just wanted to check that this would actually be accepted first :)