### PR TITLE
Add push_url()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Add ``django_htmx.http.push_url()`` for setting the browser location.
+
+  Thanks to Chris Tapper in `PR #264 <https://github.com/adamchainz/django-htmx/pull/264>`__.
+
 1.12.2 (2022-08-31)
 -------------------
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -80,6 +80,15 @@ HTTP
                return render("event-finished.html", status=HTMX_STOP_POLLING)
            ...
 
+.. autofunction:: push_url
+
+   Modify the |HX-Push-Url header|__ of ``response`` to push a URL into the browser location history, and returns the response.
+
+   .. |HX-Push-Url header| replace:: ``HX-Push-Url`` header
+   __ https://htmx.org/headers/hx-push-url/
+
+   Calling ``push_url`` multiple times for the same ``response`` will replace the value of the header.
+
 .. autofunction:: trigger_client_event
 
    Modify the |HX-Trigger headers|__ of ``response`` to trigger client-side events, and returns the response.

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -83,6 +83,7 @@ HTTP
 .. autofunction:: push_url
 
    Modify the |HX-Push-Url header|__ of ``response`` to push a URL into the browser location history, and return the response.
+   Pass a string with the URL to push, or ``False`` to prevent the location history from being updated.
 
    .. |HX-Push-Url header| replace:: ``HX-Push-Url`` header
    __ https://htmx.org/headers/hx-push-url/

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -82,7 +82,7 @@ HTTP
 
 .. autofunction:: push_url
 
-   Modify the |HX-Push-Url header|__ of ``response`` to push a URL into the browser location history, and returns the response.
+   Modify the |HX-Push-Url header|__ of ``response`` to push a URL into the browser location history, and return the response.
 
    .. |HX-Push-Url header| replace:: ``HX-Push-Url`` header
    __ https://htmx.org/headers/hx-push-url/
@@ -91,7 +91,7 @@ HTTP
 
 .. autofunction:: trigger_client_event
 
-   Modify the |HX-Trigger headers|__ of ``response`` to trigger client-side events, and returns the response.
+   Modify the |HX-Trigger headers|__ of ``response`` to trigger client-side events, and return the response.
    Takes the name of the event to trigger and any JSON-compatible parameters for it, and stores them in the appropriate header. Uses |DjangoJSONEncoder|__ for its extended data type support.
 
    .. |HX-Trigger headers| replace:: ``HX-Trigger`` headers

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -83,7 +83,7 @@ HTTP
 .. autofunction:: push_url
 
    Modify the |HX-Push-Url header|__ of ``response`` to push a URL into the browser location history, and return the response.
-   Pass a string with the URL to push, or ``False`` to prevent the location history from being updated.
+   ``url`` should be the URL to push, or ``False`` to prevent the location history from being updated.
 
    .. |HX-Push-Url header| replace:: ``HX-Push-Url`` header
    __ https://htmx.org/headers/hx-push-url/

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -49,6 +49,11 @@ class HttpResponseClientRefresh(HttpResponse):
 _R = TypeVar("_R", bound=HttpResponseBase)
 
 
+def push_url(response: _R, url: str | Literal[False]) -> _R:
+    response["HX-Push-Url"] = "false" if url is False else url
+    return response
+
+
 def trigger_client_event(
     response: _R,
     name: str,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -51,6 +51,22 @@ class HttpResponseClientRefreshTests(SimpleTestCase):
         assert response["HX-Refresh"] == "true"
 
 
+class PushUrlTests(SimpleTestCase):
+    def test_success(self):
+        response = HttpResponse()
+
+        push_url(response, "/index.html")
+
+        assert response["HX-Push-Url"] == "/index.html"
+
+    def test_success_false(self):
+        response = HttpResponse()
+
+        push_url(response, False)
+
+        assert response["HX-Push-Url"] == "false"
+
+
 class TriggerClientEventTests(SimpleTestCase):
     def test_fail_bad_after_value(self):
         response = HttpResponse()
@@ -154,19 +170,3 @@ class TriggerClientEventTests(SimpleTestCase):
             response["HX-Trigger"]
             == '{"showMessage": {"uuid": "12345678-1234-5678-1234-567812345678"}}'
         )
-
-
-class PushUrlTests(SimpleTestCase):
-    def test_success(self):
-        response = HttpResponse()
-
-        push_url(response, "/index.html")
-
-        assert response["HX-Push-Url"] == "/index.html"
-
-    def test_success_false(self):
-        response = HttpResponse()
-
-        push_url(response, False)
-
-        assert response["HX-Push-Url"] == "false"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -10,6 +10,7 @@ from django_htmx.http import (
     HttpResponseClientRedirect,
     HttpResponseClientRefresh,
     HttpResponseStopPolling,
+    push_url,
     trigger_client_event,
 )
 
@@ -153,3 +154,19 @@ class TriggerClientEventTests(SimpleTestCase):
             response["HX-Trigger"]
             == '{"showMessage": {"uuid": "12345678-1234-5678-1234-567812345678"}}'
         )
+
+
+class PushUrlTests(SimpleTestCase):
+    def test_success(self):
+        response = HttpResponse()
+
+        push_url(response, "/index.html")
+
+        assert response["HX-Push-Url"] == "/index.html"
+
+    def test_success_false(self):
+        response = HttpResponse()
+
+        push_url(response, False)
+
+        assert response["HX-Push-Url"] == "false"


### PR DESCRIPTION
Adds a helper function for setting the [`HX-Push-Url` header](https://htmx.org/headers/hx-push-url).

Couldn't make up my mind about whether the `url=False` case would be better off as a separate function... Something like `prevent_history_update(response)`. I figured it would probably be best to stick with something closer to the HTMX API. Any thoughts on this?