### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 from __future__ import annotations
 
 import sys

--- a/example/example/core/views.py
+++ b/example/example/core/views.py
@@ -4,9 +4,12 @@ import time
 from dataclasses import dataclass
 
 from django.core.paginator import Paginator
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
+from django.http import HttpResponse
 from django.shortcuts import render
-from django.views.decorators.http import require_GET, require_http_methods, require_POST
+from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import require_POST
 from faker import Faker
 
 from django_htmx.middleware import HtmxDetails

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from django.urls import path
 
-from example.core.views import (
-    csrf_demo,
-    csrf_demo_checker,
-    error_demo,
-    error_demo_trigger,
-    favicon,
-    index,
-    middleware_tester,
-    middleware_tester_table,
-    partial_rendering,
-)
+from example.core.views import csrf_demo
+from example.core.views import csrf_demo_checker
+from example.core.views import error_demo
+from example.core.views import error_demo_trigger
+from example.core.views import favicon
+from example.core.views import index
+from example.core.views import middleware_tester
+from example.core.views import middleware_tester_table
+from example.core.views import partial_rendering
 
 urlpatterns = [
     path("", index),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, TypeVar
+from typing import Any
+from typing import TypeVar
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
-from django.http.response import HttpResponseBase, HttpResponseRedirectBase
+from django.http.response import HttpResponseBase
+from django.http.response import HttpResponseRedirectBase
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Awaitable, Callable
+from typing import Any
+from typing import Awaitable
+from typing import Callable
 from urllib.parse import unquote
 
 from django.http import HttpRequest

--- a/tests/templatetags/test_django_htmx.py
+++ b/tests/templatetags/test_django_htmx.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from django.template import Context, Template
-from django.test import SimpleTestCase, override_settings
+from django.template import Context
+from django.template import Template
+from django.test import override_settings
+from django.test import SimpleTestCase
 
 
 class DjangoHtmxScriptTests(SimpleTestCase):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 from uuid import UUID
 
 import pytest
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.test import SimpleTestCase
 
-from django_htmx.http import (
-    HttpResponseClientRedirect,
-    HttpResponseClientRefresh,
-    HttpResponseStopPolling,
-    push_url,
-    trigger_client_event,
-)
+from django_htmx.http import HttpResponseClientRedirect
+from django_htmx.http import HttpResponseClientRefresh
+from django_htmx.http import HttpResponseStopPolling
+from django_htmx.http import push_url
+from django_htmx.http import trigger_client_event
 
 
 class HttpResponseStopPollingTests(SimpleTestCase):

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
 
 from django_htmx.jinja import django_htmx_script
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
+from typing import cast
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
@@ -8,7 +9,8 @@ from django.http.response import HttpResponseBase
 from django.test import RequestFactory as BaseRequestFactory
 from django.test import SimpleTestCase
 
-from django_htmx.middleware import HtmxDetails, HtmxMiddleware
+from django_htmx.middleware import HtmxDetails
+from django_htmx.middleware import HtmxMiddleware
 
 
 class HtmxWSGIRequest(WSGIRequest):


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
