### PR TITLE
Add htmx_view decorator

### DIFF
--- a/src/django_htmx/decorators.py
+++ b/src/django_htmx/decorators.py
@@ -1,0 +1,13 @@
+from functools import wraps
+
+from django.http import HttpResponseNotFound
+
+
+def htmx_view(view_func):
+    @wraps(view_func)
+    def wrap(request, *args, **kwargs):
+        if request.htmx:
+            return view_func(request, *args, **kwargs)
+        return HttpResponseNotFound()
+
+    return wrap

--- a/src/django_htmx/decorators.py
+++ b/src/django_htmx/decorators.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from functools import wraps
 from typing import Callable
 
-from django.http import HttpRequest, HttpResponseNotFound
+from django.http import HttpRequest
+from django.http import HttpResponseNotFound
 
 
 def htmx_view(view_func: Callable):

--- a/src/django_htmx/decorators.py
+++ b/src/django_htmx/decorators.py
@@ -1,11 +1,12 @@
 from functools import wraps
+from typing import Callable
 
-from django.http import HttpResponseNotFound
+from django.http import HttpRequest, HttpResponseNotFound
 
 
-def htmx_view(view_func):
+def htmx_view(view_func: Callable):
     @wraps(view_func)
-    def wrap(request, *args, **kwargs):
+    def wrap(request: HttpRequest, *args, **kwargs):
         if request.htmx:
             return view_func(request, *args, **kwargs)
         return HttpResponseNotFound()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+from unittest import mock
+
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse
+from django.test import RequestFactory as BaseRequestFactory
+from django.test import SimpleTestCase
+
+from django_htmx.decorators import htmx_view
+from django_htmx.middleware import HtmxDetails, HtmxMiddleware
+
+
+class HtmxWSGIRequest(WSGIRequest):
+    htmx: HtmxDetails
+
+
+class RequestFactory(BaseRequestFactory):
+    def get(
+        self, path: str, data: Any = None, secure: bool = False, **extra: Any
+    ) -> HtmxWSGIRequest:
+        return cast(HtmxWSGIRequest, super().get(path, data, secure, **extra))
+
+
+def dummy_view(request):
+    return HttpResponse("Hello!")
+
+
+class HTMXDecoratorsTests(SimpleTestCase):
+    request_factory = RequestFactory()
+    middleware = HtmxMiddleware(dummy_view)
+
+    def test_htmx_request(self):
+        request = self.request_factory.get("/", HTTP_HX_REQUEST="true")
+        self.middleware(request)
+        func = mock.Mock()
+        decorated_func = htmx_view(func)
+        response = decorated_func(request)
+        assert func.called
+
+    def test_non_htmx_request(self):
+        request = self.request_factory.get("/", HTTP_HX_REQUEST="false")
+        self.middleware(request)
+        func = mock.Mock()
+        decorated_func = htmx_view(func)
+        response = decorated_func(request)
+        assert not func.called

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -37,7 +37,7 @@ class HTMXDecoratorsTests(SimpleTestCase):
         self.middleware(request)
         func = mock.Mock()
         decorated_func = htmx_view(func)
-        response = decorated_func(request)
+        response = decorated_func(request)  # noqa: F841
         assert func.called
 
     def test_non_htmx_request(self):
@@ -45,5 +45,5 @@ class HTMXDecoratorsTests(SimpleTestCase):
         self.middleware(request)
         func = mock.Mock()
         decorated_func = htmx_view(func)
-        response = decorated_func(request)
+        response = decorated_func(request)  # noqa: F841
         assert not func.called


### PR DESCRIPTION
Sometimes I want my views to be htmx only and return 404 if the request is not made with htmx.
I've made a decorator in my project but I thought I can't be the only one who checks `if request.htmx...` to process the view hence I made the PR.

I wasn't sure if this is the best way to rest view decorators so I'm open to suggestions in that matter.