### PR TITLE
Add details class option

### DIFF
--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -18,6 +18,7 @@ from django.utils.functional import cached_property
 class HtmxMiddleware:
     sync_capable = True
     async_capable = True
+    details_class = None
 
     def __init__(
         self,
@@ -27,6 +28,7 @@ class HtmxMiddleware:
         ),
     ) -> None:
         self.get_response = get_response
+        self.details_class = self.details_class or HtmxDetails
         self.async_mode = iscoroutinefunction(self.get_response)
 
         if self.async_mode:
@@ -39,11 +41,11 @@ class HtmxMiddleware:
     ) -> HttpResponseBase | Awaitable[HttpResponseBase]:
         if self.async_mode:
             return self.__acall__(request)
-        request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
+        request.htmx = self.details_class(request)  # type: ignore [attr-defined]
         return self.get_response(request)
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
-        request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
+        request.htmx = self.details_class(request)  # type: ignore [attr-defined]
         return await self.get_response(request)  # type: ignore [no-any-return, misc]
 
 

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -18,7 +18,7 @@ from django.utils.functional import cached_property
 class HtmxMiddleware:
     sync_capable = True
     async_capable = True
-    details_class = None
+    details_class = None  # type: ignore
 
     def __init__(
         self,

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -18,7 +18,7 @@ from django.utils.functional import cached_property
 class HtmxMiddleware:
     sync_capable = True
     async_capable = True
-    details_class = None  # type: ignore
+    details_class = None
 
     def __init__(
         self,
@@ -41,11 +41,11 @@ class HtmxMiddleware:
     ) -> HttpResponseBase | Awaitable[HttpResponseBase]:
         if self.async_mode:
             return self.__acall__(request)
-        request.htmx = self.details_class(request)  # type: ignore [attr-defined]
+        request.htmx = self.details_class(request)  # type: ignore
         return self.get_response(request)
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
-        request.htmx = self.details_class(request)  # type: ignore [attr-defined]
+        request.htmx = self.details_class(request)  # type: ignore
         return await self.get_response(request)  # type: ignore [no-any-return, misc]
 
 


### PR DESCRIPTION
I actually faced this problem where I wanted to change the `__bool__()` of the  HtmxDetails, It was easy to spin up but I made it easier for  people 

now when anyone wants to change the HtmxDetails class and use a custom one he will just do this

```python
from django_htmx import HtmxMiddleware, HtmxDetails

class MyDetailsClass(HtmxDetails):
    # do anything here

class MyMiddleware(HtmxMiddleware):
    details_class = MyDetailsClass
```

But I have a question ... should I add a method in the middleware to get the details class or is this enough??

Another thing is that I think that if this pull request will be merged we need to document this but the problem is that I didn't deal with RTD before so I think you will have to do this yourself 