### PR TITLE
Add redirect_middleware for handling htmx request redirects

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -128,16 +128,16 @@ Middleware
    .. code-block:: python
 
      def redirect_middleware(get_response):
-        def middleware(request):
-           response = get_response(request)
-           if request.headers.get("HX-Request") and response.status_code == 302:
-              location = urlparse(response["Location"])
-              if location.path == settings.LOGIN_URL:
-                 redirect_url = (
-                    f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
-                 )
-                 response["HX-Redirect"] = redirect_url
-                 response.status_code = 204
-           return response
+         def middleware(request):
+             response = get_response(request)
+             if request.headers.get("HX-Request") and response.status_code == 302:
+                 location = urlparse(response["Location"])
+                 if location.path == settings.LOGIN_URL:
+                     redirect_url = (
+                         f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+                     )
+                     response["HX-Redirect"] = redirect_url
+                     response.status_code = 204
+             return response
 
-        return middleware
+         return middleware

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -113,3 +113,31 @@ Middleware
 
       The deserialized JSON representation of the event that triggered the request if it exists, or ``None``.
       This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
+
+
+.. function:: redirect_middleware(get_response)
+
+   Middleware to handle redirects for htmx requests for login required views.
+
+   :param get_response: A function that takes a request and returns a response.
+   :type get_response: callable
+   :returns: A middleware function that takes a request and returns a response.
+
+   The middleware function checks if the request is an htmx request and if the response status code is 302 (redirection). If so, it parses the redirection location. If the redirection location is the login URL, it changes the redirection URL to point to the login redirect URL and changes the response status code to 204 (No Content). The modified response is then returned.
+
+   .. code-block:: python
+
+     def redirect_middleware(get_response):
+        def middleware(request):
+           response = get_response(request)
+           if request.headers.get("HX-Request") and response.status_code == 302:
+              location = urlparse(response["Location"])
+              if location.path == settings.LOGIN_URL:
+                 redirect_url = (
+                    f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+                 )
+                 response["HX-Redirect"] = redirect_url
+                 response.status_code = 204
+           return response
+
+        return middleware

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -112,3 +112,23 @@ class HtmxDetails:
             except json.JSONDecodeError:
                 value = None
         return value
+
+from urllib.parse import urlparse
+from django.conf import settings
+
+
+def redirect_middleware(get_response):
+    """Middleware to handle redirects for htmx requests for login required views"""
+    def middleware(request):
+        response = get_response(request)
+        if request.headers.get("HX-Request") and response.status_code == 302:
+            location = urlparse(response["Location"])
+            if location.path == settings.LOGIN_URL:
+                redirect_url = (
+                    f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+                )
+                response["HX-Redirect"] = redirect_url
+                response.status_code = 204
+        return response
+
+    return middleware

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -113,12 +113,14 @@ class HtmxDetails:
                 value = None
         return value
 
+
 from urllib.parse import urlparse
 from django.conf import settings
 
 
 def redirect_middleware(get_response):
     """Middleware to handle redirects for htmx requests for login required views"""
+
     def middleware(request):
         response = get_response(request)
         if request.headers.get("HX-Request") and response.status_code == 302:

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -5,16 +5,16 @@ from typing import Any
 from typing import Awaitable
 from typing import Callable
 from urllib.parse import unquote
+from urllib.parse import urlparse
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
-from urllib.parse import urlparse
 
 from asgiref.sync import iscoroutinefunction
 from asgiref.sync import markcoroutinefunction
+from django.conf import settings
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.functional import cached_property
-from django.conf import settings
 
 
 class HtmxMiddleware:

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -7,12 +7,14 @@ from typing import Callable
 from urllib.parse import unquote
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+from urllib.parse import urlparse
 
 from asgiref.sync import iscoroutinefunction
 from asgiref.sync import markcoroutinefunction
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.functional import cached_property
+from django.conf import settings
 
 
 class HtmxMiddleware:
@@ -112,10 +114,6 @@ class HtmxDetails:
             except json.JSONDecodeError:
                 value = None
         return value
-
-
-from urllib.parse import urlparse
-from django.conf import settings
 
 
 def redirect_middleware(get_response):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 from typing import cast
 
+from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 from django.http.response import HttpResponseBase
@@ -13,8 +14,6 @@ from django.test.utils import override_settings
 from django_htmx.middleware import HtmxDetails
 from django_htmx.middleware import HtmxMiddleware
 from django_htmx.middleware import redirect_middleware
-
-from django.conf import settings
 
 
 class HtmxWSGIRequest(WSGIRequest):
@@ -193,11 +192,14 @@ class RedirectMiddlewareTests(SimpleTestCase):
     def dummy_view(self, request):
         return HttpResponse()
 
-    @override_settings(LOGIN_URL='/login/', LOGIN_REDIRECT_URL='/home/')
+    @override_settings(LOGIN_URL="/login/", LOGIN_REDIRECT_URL="/home/")
     def test_redirect_middleware(self):
         request = self.factory.get("/", HTTP_HX_REQUEST="true")
         response = HttpResponse(status=302)
         response["Location"] = settings.LOGIN_URL
         response = self.middleware(request)
         assert response.status_code == 204
-        assert response["HX-Redirect"] == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+        assert (
+            response["HX-Redirect"]
+            == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+        )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -191,11 +191,14 @@ class RedirectMiddlewareTests(SimpleTestCase):
     def dummy_view(self, request):
         return HttpResponse()
 
-    @override_settings(LOGIN_URL='/login/', LOGIN_REDIRECT_URL='/home/')
+    @override_settings(LOGIN_URL="/login/", LOGIN_REDIRECT_URL="/home/")
     def test_redirect_middleware(self):
         request = self.factory.get("/", HTTP_HX_REQUEST="true")
         response = HttpResponse(status=302)
         response["Location"] = settings.LOGIN_URL
         response = self.middleware(request)
         assert response.status_code == 204
-        assert response["HX-Redirect"] == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+        assert (
+            response["HX-Redirect"]
+            == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
+        )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -195,6 +195,7 @@ class RedirectMiddlewareTests(SimpleTestCase):
     @override_settings(LOGIN_URL="/login/", LOGIN_REDIRECT_URL="/home/")
     def test_redirect_middleware(self):
         request = self.factory.get("/", HTTP_HX_REQUEST="true")
+        request["HX-Request"] = "true"
         response = HttpResponse(status=302)
         response["Location"] = settings.LOGIN_URL
         response = self.middleware(request)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,6 +14,8 @@ from django_htmx.middleware import HtmxDetails
 from django_htmx.middleware import HtmxMiddleware
 from django_htmx.middleware import redirect_middleware
 
+from django.conf import settings
+
 
 class HtmxWSGIRequest(WSGIRequest):
     htmx: HtmxDetails
@@ -191,14 +193,11 @@ class RedirectMiddlewareTests(SimpleTestCase):
     def dummy_view(self, request):
         return HttpResponse()
 
-    @override_settings(LOGIN_URL="/login/", LOGIN_REDIRECT_URL="/home/")
+    @override_settings(LOGIN_URL='/login/', LOGIN_REDIRECT_URL='/home/')
     def test_redirect_middleware(self):
         request = self.factory.get("/", HTTP_HX_REQUEST="true")
         response = HttpResponse(status=302)
         response["Location"] = settings.LOGIN_URL
         response = self.middleware(request)
         assert response.status_code == 204
-        assert (
-            response["HX-Redirect"]
-            == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"
-        )
+        assert response["HX-Redirect"] == f"{settings.LOGIN_URL}?next={settings.LOGIN_REDIRECT_URL}"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -195,7 +195,6 @@ class RedirectMiddlewareTests(SimpleTestCase):
     @override_settings(LOGIN_URL="/login/", LOGIN_REDIRECT_URL="/home/")
     def test_redirect_middleware(self):
         request = self.factory.get("/", HTTP_HX_REQUEST="true")
-        request["HX-Request"] = "true"
         response = HttpResponse(status=302)
         response["Location"] = settings.LOGIN_URL
         response = self.middleware(request)


### PR DESCRIPTION
This commit adds a new function, `redirect_middleware`, to handle redirects for htmx requests for login required views. 

This should address issues where htmx performs a request against a view decorated with `@login_required`.

The middleware function checks if the request is an htmx request and if the response status code is 302 (redirection). If so, it parses the redirection location. If the redirection location is the login URL, it changes the redirection URL to point to the login redirect URL and changes the response status code to 204 (No Content). The modified response is then returned.

The `redirect_middleware` function is added to the `django_htmx/middleware.py` file.