### PR TITLE
Add HttpRequest subclass with htmx property type hint

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -104,3 +104,20 @@ Here, ``_base.html`` would be the main site base:
    </main>
 
 For an example of this in action, see the “Partial Rendering” page of the :doc:`example project <example_project>`.
+
+Type Hints
+----------
+
+For autocompletion with the `request.htmx` property and and to avoid type-checking errors, such as those identified by mypy, regarding a non-existent property, this package provides
+an `HttpRequest` subclass. This subclass adds the `htmx` property type hint to the request object. Here's how to use it:
+
+.. code-block:: python
+
+   from django_htmx.http import HttpRequest
+
+
+   def my_view(request: HtmxRequest) -> HttpResponse:
+       if request.htmx:
+           ...
+       else:
+           ...

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -3,15 +3,24 @@ from __future__ import annotations
 import json
 from typing import Any
 from typing import Literal
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpRequest as HttpRequestBase
 from django.http import HttpResponse
 from django.http.response import HttpResponseBase
 from django.http.response import HttpResponseRedirectBase
 
+if TYPE_CHECKING:
+    from .middleware import HtmxDetails
+
 
 HTMX_STOP_POLLING = 286
+
+
+class HttpRequest(HttpRequestBase):
+    htmx: HtmxDetails
 
 
 class HttpResponseStopPolling(HttpResponse):


### PR DESCRIPTION
I added this for convenience, I don't know how others handle this, but I was tired of having to add `# type: ignore` every time I use `request.htmx`.

```python
class HttpRequest(HttpRequestBase):
    htmx: HtmxDetails
```