### PR TITLE
Add example for polling with reswap and HttpResponseStopPolling

### DIFF
--- a/example/example/templates/_base.html
+++ b/example/example/templates/_base.html
@@ -38,6 +38,9 @@
           <a href="/error-demo/">Error Demo</a>
         </li>
         <li>
+          <a href="/polling-demo/">Polling Demo</a>
+        </li>
+        <li>
           <a href="/middleware-tester/">Middleware Tester</a>
         </li>
         <li>

--- a/example/example/templates/polling-demo.html
+++ b/example/example/templates/polling-demo.html
@@ -1,0 +1,15 @@
+{% extends "_base.html" %}
+
+{% block main %}
+  <section>
+    <p>
+      This example shows how to use <a href="https://dev.htmx.org/attributes/hx-trigger/">the <code>hx-trigger</code> attribute</a> to poll a server for updates until it responds with <a href="https://dev.htmx.org/docs/#polling">HTTP 286</a>.
+    </p>
+  </section>
+  <section>
+    <blockquote hx-get="/polling-demo/" hx-trigger="every 1s" hx-target="find span">
+      "<span>...</span>"
+      <footer><i>- Bono, U2 - Vertigo, 2004</i></footer>
+    </blockquote>
+  </section>
+{% endblock %}

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("csrf-demo/checker/", views.csrf_demo_checker),
     path("error-demo/", views.error_demo),
     path("error-demo/trigger/", views.error_demo_trigger),
+    path("polling-demo/", views.polling_demo),
     path("middleware-tester/", views.middleware_tester),
     path("middleware-tester/table/", views.middleware_tester_table),
     path("partial-rendering/", views.partial_rendering),

--- a/example/example/views.py
+++ b/example/example/views.py
@@ -12,7 +12,8 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_POST
 from faker import Faker
 
-from django_htmx.http import HttpResponseStopPolling, reswap
+from django_htmx.http import HttpResponseStopPolling
+from django_htmx.http import reswap
 from django_htmx.middleware import HtmxDetails
 from example.forms import OddNumberForm
 

--- a/example/example/views.py
+++ b/example/example/views.py
@@ -12,6 +12,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_POST
 from faker import Faker
 
+from django_htmx.http import HttpResponseStopPolling, reswap
 from django_htmx.middleware import HtmxDetails
 from example.forms import OddNumberForm
 
@@ -74,6 +75,27 @@ def error_demo(request: HtmxHttpRequest) -> HttpResponse:
 def error_demo_trigger(request: HtmxHttpRequest) -> HttpResponse:
     1 / 0
     return render(request, "error-demo.html")  # unreachable
+
+
+# Polling Demo
+
+_countdown = None
+
+
+@require_GET
+def polling_demo(request: HtmxHttpRequest) -> HttpResponse:
+    global _countdown
+
+    if request.htmx:
+        try:
+            return HttpResponse(next(_countdown))
+        except StopIteration:
+            response = HttpResponseStopPolling()
+            reswap(response, "none")
+            return response
+
+    _countdown = iter(["Unos", "Dos", "Tres", "Catorce!"])
+    return render(request, "polling-demo.html")
 
 
 # Middleware tester


### PR DESCRIPTION
Thank you for another useful, little package for Django, Adam! :heart:

Clicking through the examples after reading the docs, I thought maybe a demo for a timed trigger and HTTP 286 (without swapping!) would be a good addition.