### PR TITLE
Change reswap() type hint for method to str

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Change ``reswap()`` type hint for ``method`` to ``str``.
+
+  Thanks to Dan Jacob for the report in `Issue #421 <https://github.com/adamchainz/django-htmx/issues/421>`__ and fix in `PR #422 <https://github.com/adamchainz/django-htmx/pull/422>`__.
+
 1.17.2 (2023-11-16)
 -------------------
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -93,19 +93,7 @@ def push_url(response: _HttpResponse, url: str | Literal[False]) -> _HttpRespons
     return response
 
 
-def reswap(
-    response: _HttpResponse,
-    method: Literal[
-        "innerHTML",
-        "outerHTML",
-        "beforebegin",
-        "afterbegin",
-        "beforeend",
-        "afterend",
-        "delete",
-        "none",
-    ],
-) -> _HttpResponse:
+def reswap(response: _HttpResponse, method: str) -> _HttpResponse:
     response["HX-Reswap"] = method
     return response
 


### PR DESCRIPTION
Fix for https://github.com/adamchainz/django-htmx/issues/421

The `HX-Swap` directive and `HX-Reswap` response header allow modifiers in addition to the method, for example:

```html
<div hx-swap="outerHTML show:window:top"><div>
```

This change allows any `str` value to be used for the method:

```python
reswap(response, "outerHTML show:window:top")
```
