### PR TITLE
context_processors: Created basic context processor for setting base template

### DIFF
--- a/src/django_htmx/context_processors.py
+++ b/src/django_htmx/context_processors.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""django-htmx related context processors.
+"""
+from __future__ import annotations
+from django.http import HttpRequest
+from typing import Dict
+
+
+def base_template(request: HttpRequest) -> Dict[str, str]:
+    """Sets the base_template context variable.
+
+    If the request is a htmx request, the `base_template` will be set to a partial template.
+    Otherwise, it will be set to a full template.
+    Parameters:
+    - request: Current request object.
+    Returns:
+    - dict: A dictionary with a key set to `base_template` and the appropriate value.
+    """
+
+    if request.htmx:
+        base_template_var = "_partial.html"
+    else:
+        base_template_var = "_base.html"
+    return dict(base_template=base_template_var)

--- a/src/django_htmx/context_processors.py
+++ b/src/django_htmx/context_processors.py
@@ -1,12 +1,14 @@
-# -*- coding: utf-8 -*-
 """django-htmx related context processors.
 """
+
 from __future__ import annotations
-from django.http import HttpRequest
+
 from typing import Dict
 
+from django.http import HttpRequest
 
-def base_template(request: HttpRequest) -> Dict[str, str]:
+
+def base_template(request: HttpRequest) -> dict[str, str]:
     """Sets the base_template context variable.
 
     If the request is a htmx request, the `base_template` will be set to a partial template.


### PR DESCRIPTION
Inspired by the [tips](https://django-htmx.readthedocs.io/en/latest/tips.html) of django-htmx docs, I created a context processor that sets the base template to a partial template if the request is a htmx request, else to a full template.
This pull request currently has a basic implementation with some hard-coded values that will not be suitable for django-htmx.
The hard-coded values are of both the base_template variable and it's value. To eliminate this, I am going to make the function to look for both values in the `settings.py` file. For example:

```python
DJANGO_HTMX_BASE_TEMPLATE = {
    "variable_name": "base_template",
    "values": {
        "full": "_base.html",
        "partial": "_partial.html"
    }
}
```

> Any suggestions for the naming of the variable or the structure of the dictionary is welcomed.

If the variable or some of it's values doesn't exist, I will use the above as the default.

Another thing is to allow a user to override this values, perhaps by calling a function, but that can wait.
Now, I need green light to proceed. What do you think?