### PR TITLE
Add django-htmx to example requirements

### DIFF
--- a/example/requirements.in
+++ b/example/requirements.in
@@ -1,2 +1,3 @@
 django
 faker
+django-htmx


### PR DESCRIPTION
django-htmx is required to run examples.