### PR TITLE
Add 'select' parameter to HttpResponseLocation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Add ``select`` parameter to ``HttpResponseLocation``.
+
+  Thanks to Nikola Anović in `PR #462 <https://github.com/adamchainz/django-htmx/pull/462>`__.
+
 1.18.0 (2024-06-19)
 -------------------
 

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -82,6 +82,9 @@ Response classes
    :param swap:
       How the response will be swapped into the target.
 
+   :param select:
+      Select the content that will be swapped from a response.
+
    :param values:
       values to submit with the request.
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -61,6 +61,7 @@ class HttpResponseLocation(HttpResponseRedirectBase):
             "none",
             None,
         ] = None,
+        select: str | None = None,
         values: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
         **kwargs: Any,
@@ -78,6 +79,8 @@ class HttpResponseLocation(HttpResponseRedirectBase):
             spec["target"] = target
         if swap is not None:
             spec["swap"] = swap
+        if select is not None:
+            spec["select"] = select
         if headers is not None:
             spec["headers"] = headers
         if values is not None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -60,6 +60,7 @@ class HttpResponseLocationTests(SimpleTestCase):
             event="doubleclick",
             target="#main",
             swap="innerHTML",
+            select="#content",
             headers={"year": "2022"},
             values={"banner": "true"},
         )
@@ -73,6 +74,7 @@ class HttpResponseLocationTests(SimpleTestCase):
             "event": "doubleclick",
             "target": "#main",
             "swap": "innerHTML",
+            "select": "#content",
             "headers": {"year": "2022"},
             "values": {"banner": "true"},
         }


### PR DESCRIPTION
Extend `HttpResponseLocation` to support select as an option. Fixes #461.