### PR TITLE
Remove unneeded furo version pin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 django
-furo!=2023.8.19
+furo
 sphinx


### PR DESCRIPTION
There have been half a dozen releases since the problem version, which itself was yanked, so it seems highly unlikely anyone would end up trying to install it.

https://pypi.org/project/furo/#history