### PR TITLE
Fix link to the event-header htmx extension

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -152,4 +152,4 @@ Middleware
       :type: Any | None
 
       The deserialized JSON representation of the event that triggered the request if it exists, or ``None``.
-      This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
+      This header is set by the `event-header htmx extension <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md>`__, and contains details of the DOM event that triggered the request.


### PR DESCRIPTION
IIRC the HTMX was restructured, maybe around 2.0 🤔 Anyhow, old link was 404ing. 