### PR TITLE
Update htmx documentation links

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -210,7 +210,7 @@ Changelog
 * Support the ``HX-History-Restore-Request`` header, which was added in htmx 1.2.0.
   This is parsed into the ``request.htmx.history_restore_request`` attribute.
 
-* Support the ``Triggering-Event`` header, which is sent by the `event-header extension <https://htmx.org/extensions/event-header/>`__.
+* Support the ``Triggering-Event`` header, which is sent by the `event-header extension <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md>`__.
   This is parsed into the ``request.htmx.triggering_event`` attribute.
 
 * Stop distributing tests to reduce package size.

--- a/docs/extension_script.rst
+++ b/docs/extension_script.rst
@@ -70,4 +70,4 @@ See this in action in the “Error Demo” section of the :doc:`example project 
 
 .. hint::
 
-   This extension script should not be confused with htmx’s `debug extension <https://htmx.org/extensions/debug/>`__, which logs DOM events in the browser console.
+   This extension script should not be confused with htmx’s `debug extension <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md>`__, which logs DOM events in the browser console.

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -152,4 +152,4 @@ Middleware
       :type: Any | None
 
       The deserialized JSON representation of the event that triggered the request if it exists, or ``None``.
-      This header is set by the `event-header htmx extension <https://htmx.org/extensions/event-header/>`__, and contains details of the DOM event that triggered the request.
+      This header is set by the `event-header htmx extension <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md>`__, and contains details of the DOM event that triggered the request.

--- a/example/README.rst
+++ b/example/README.rst
@@ -14,5 +14,5 @@ Open it at http://127.0.0.1:8000/ .
 
 Browse the individual examples, and take them apart!
 
-In your browser’s devtools, you can read the htmx `debug log <https://htmx.org/extensions/debug/>`__ in your browser’s console, and see the requests made in the network tab.
+In your browser’s devtools, you can read the htmx `debug log <https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md>`__ in your browser’s console, and see the requests made in the network tab.
 In the source code, check out the HTML comments via “view source” or templates, and the view code in ``example/views.py``.

--- a/example/example/static/htmx.js
+++ b/example/example/static/htmx.js
@@ -5122,8 +5122,7 @@ var htmx = (function() {
 
 /**
  * @typedef {Object} HtmxExtension
- * For version 1 HTMX: @see https://v1.htmx.org/extensions/#defining
- * For version 2 HTMX: @see https://htmx.org/extensions/building/
+ * @see https://htmx.org/extensions/#defining
  * @property {(api: any) => void} init
  * @property {(name: string, event: Event|CustomEvent) => boolean} onEvent
  * @property {(text: string, xhr: XMLHttpRequest, elt: Element) => string} transformResponse

--- a/example/example/static/htmx.js
+++ b/example/example/static/htmx.js
@@ -5122,7 +5122,8 @@ var htmx = (function() {
 
 /**
  * @typedef {Object} HtmxExtension
- * @see https://htmx.org/extensions/#defining
+ * For version 1 HTMX: @see https://v1.htmx.org/extensions/#defining
+ * For version 2 HTMX: @see https://htmx.org/extensions/building/
  * @property {(api: any) => void} init
  * @property {(name: string, event: Event|CustomEvent) => boolean} onEvent
  * @property {(text: string, xhr: XMLHttpRequest, elt: Element) => string} transformResponse

--- a/example/example/templates/_base.html
+++ b/example/example/templates/_base.html
@@ -17,11 +17,9 @@
 </head>
 
 <!--
-  Enable htmx extensions for all requests - depending on HTMX Version:
-  * debug v1 HTMX: https://v1.htmx.org/extensions/debug/
-  * debug v2 HTMX: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md
-  * event-header for v1 HTMX: https://v1.htmx.org/extensions/event-header/
-  * event-header for v2 HTMX: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md
+  Enable htmx extensions for all requests:
+  * debug: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md
+  * event-header: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md
 -->
 <body hx-ext="debug, event-header">
   <header>

--- a/example/example/templates/_base.html
+++ b/example/example/templates/_base.html
@@ -17,9 +17,11 @@
 </head>
 
 <!--
-  Enable htmx extensions for all requests:
-  * debug: https://htmx.org/extensions/debug/
-  * event-header: https://htmx.org/extensions/event-header/
+  Enable htmx extensions for all requests - depending on HTMX Version:
+  * debug v1 HTMX: https://v1.htmx.org/extensions/debug/
+  * debug v2 HTMX: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/debug/README.md
+  * event-header for v1 HTMX: https://v1.htmx.org/extensions/event-header/
+  * event-header for v2 HTMX: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md
 -->
 <body hx-ext="debug, event-header">
   <header>

--- a/example/example/templates/middleware-tester-table.html
+++ b/example/example/templates/middleware-tester-table.html
@@ -57,7 +57,7 @@
     <tr>
       <td>
         <code>request.htmx.triggering_event</code> <br>
-        <small>(via <a href="https://htmx.org/extensions/event-header/">event-header extension</a>)</small>
+        <small>(via <a href="https://v1.htmx.org/extensions/event-header/">event-header extension</a>)</small>
       </td>
       <td>
         {% if request.htmx.triggering_event %}

--- a/example/example/templates/middleware-tester-table.html
+++ b/example/example/templates/middleware-tester-table.html
@@ -57,7 +57,7 @@
     <tr>
       <td>
         <code>request.htmx.triggering_event</code> <br>
-        <small>(via <a href="https://v1.htmx.org/extensions/event-header/">event-header extension</a>)</small>
+        <small>(via <a href="https://github.com/bigskysoftware/htmx-extensions/blob/main/src/event-header/README.md">event-header extension</a>)</small>
       </td>
       <td>
         {% if request.htmx.triggering_event %}


### PR DESCRIPTION
Going to put "**Evaluate**" to try to clarify which ones might be better to be just moved over to the "https://v1.htmx.org" rather than pointing to v2's readme's. Whatever maintainer's preference. 

@carltongibson - Added both your #492 and my #498. I don't contribute a lot to public repos, so let me know if that's a faux pas or anything.

- docs/changelog.rst - **Evaluate** Pointed to latest version of docs hosted on github. This one should be evaluated if you 
- docs/extension_script.rst - Pointed to latest docs, old one 404s. adding "v1." before htmx.org also fixes this, but points to an old version of htmx.
- docs/middleware.rst - Matches PR #492 - Should merge cleanly
- example/README.rst - Pointed to latest docs, old one 404s. adding "v1." before htmx.org also fixes this, but points to an old version of htmx.
- example/example/static/htmx.js - **Evaluate** This is a comment that points to the `#extensions` header of the docs, which _does not_ 404, but does point to a somewhat irrelevant page. My thought was that both version would be helpful if someone is this in the weeds and the fact it doesn't affect the code. (I think - I'm not a big JS dev)
    - Added in a v1 page that correctly directs to the header reference.
    - Added in the latest version as well underneath
- example/example/templates/_base.html - **Evaluate** This is another comment that is pointing to docs. I added in v1 and v2 versioning. Used the same logic as static/htmx.js 's commented area - won't impact the code.
- example/example/templates/middleware-tester-table.html - Added in "v1" before the htmx.org domain.