### PR TITLE
Share `SwapMethod` literal type with the `reswap` helper

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 
 * Improve typing of ``reswap()`` to only accept valid HTMX swap methods.
 
+  Thanks to Thibaut Decombe in `PR #555 <https://github.com/adamchainz/django-htmx/pull/555>`__.
+
 1.25.0 (2025-09-18)
 -------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Improve typing of ``reswap()`` to only accept valid HTMX swap methods.
+
 1.25.0 (2025-09-18)
 -------------------
 

--- a/src/django_htmx/http.py
+++ b/src/django_htmx/http.py
@@ -9,6 +9,17 @@ from django.http.response import HttpResponseBase, HttpResponseRedirectBase
 
 HTMX_STOP_POLLING = 286
 
+SwapMethod = Literal[
+    "innerHTML",
+    "outerHTML",
+    "beforebegin",
+    "afterbegin",
+    "beforeend",
+    "afterend",
+    "delete",
+    "none",
+]
+
 
 class HttpResponseStopPolling(HttpResponse):
     status_code = HTMX_STOP_POLLING
@@ -47,17 +58,7 @@ class HttpResponseLocation(HttpResponseRedirectBase):
         source: str | None = None,
         event: str | None = None,
         target: str | None = None,
-        swap: Literal[
-            "innerHTML",
-            "outerHTML",
-            "beforebegin",
-            "afterbegin",
-            "beforeend",
-            "afterend",
-            "delete",
-            "none",
-            None,
-        ] = None,
+        swap: SwapMethod | None = None,
         select: str | None = None,
         values: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
@@ -98,7 +99,7 @@ def replace_url(response: _HttpResponse, url: str | Literal[False]) -> _HttpResp
     return response
 
 
-def reswap(response: _HttpResponse, method: str) -> _HttpResponse:
+def reswap(response: _HttpResponse, method: SwapMethod) -> _HttpResponse:
     response["HX-Reswap"] = method
     return response
 


### PR DESCRIPTION
This improves the typing of `reswap()` to only accept valid HTMX swap methods.

From the [htmx docs](https://htmx.org/reference/#response_headers)

> HX-Reswap -- allows you to specify how the response will be swapped. See [hx-swap](https://htmx.org/attributes/hx-swap/) for possible values


PS: I'm not familiar with sphinx but i suppose the documentation will be updated automatically ?