### PR TITLE
Add HtmxClient and testing assertions (Fixes #583)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ This package provides an easy way to include htmx in your Django projects and to
    middleware
    template_tags
    http
+   testing
    example_project
    tips
    changelog

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,55 @@
+Testing
+=======
+
+.. currentmodule:: django_htmx.testing
+
+Testing htmx views can be repetitive as they usually switch behaviour based on htmx-specific headers.
+The ``django_htmx.testing`` module provides tools to simplify this.
+
+.. class:: HtmxClient
+
+   A subclass of Django’s :class:`~django.test.client.Client` that adds an ``htmx`` argument to all request methods (``get()``, ``post()``, etc.).
+
+   When ``htmx`` is set, the client automatically adds htmx-specific headers to the request.
+
+   If ``htmx=True``, the ``HX-Request`` header is set to ``"true"``:
+
+   .. code-block:: python
+
+       from django_htmx.testing import HtmxClient
+
+       client = HtmxClient()
+
+       def test_htmx_view(self):
+           # Simple htmx request
+           response = client.get("/my-view/", htmx=True)
+           assert response.status_code == 200
+
+   If ``htmx`` is a :class:`dict`, the keys are mapped to htmx headers.
+   The ``HX-Request`` header is always set to ``"true"`` in this case:
+
+   .. code-block:: python
+
+       def test_htmx_target(self):
+           # Request with a specific target
+           response = client.get("/my-view/", htmx={"target": "#info-pane"})
+           assert response.status_code == 200
+
+   The following keys are supported in the ``htmx`` dictionary:
+
+   * ``boosted`` (maps to ``HX-Boosted``)
+   * ``current_url`` (maps to ``HX-Current-URL``)
+   * ``history_restore_request`` (maps to ``HX-History-Restore-Request``)
+   * ``prompt`` (maps to ``HX-Prompt``)
+   * ``target`` (maps to ``HX-Target``)
+   * ``trigger`` (maps to ``HX-Trigger``)
+   * ``trigger_name`` (maps to ``HX-Trigger-Name``)
+
+   Passing any other key will raise a :class:`ValueError`.
+
+   Using the client without the ``htmx`` argument (or setting it to ``False`` or ``None``) results in a normal non-htmx request.
+
+.. class:: HtmxClientMixin
+
+   A mixin that can be added to custom client classes to add the ``htmx`` argument support.
+   This is what :class:`HtmxClient` uses internally.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -20,6 +20,7 @@ The ``django_htmx.testing`` module provides tools to simplify this.
 
        client = HtmxClient()
 
+
        def test_htmx_view(self):
            # Simple htmx request
            response = client.get("/my-view/", htmx=True)

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from typing import Any
+from django.test.client import Client
+
+
+class HtmxClientMixin:
+    def request(self, **request: Any) -> Any:
+        request.setdefault("HTTP_HX_REQUEST", "true")
+        return super().request(**request)  # type: ignore [misc]
+
+
+class HtmxClient(HtmxClientMixin, Client):
+    pass
+
+
+class HtmxTestCaseAssertions:
+    def assertHtmxClientRedirect(
+        self, response: Any, expected_url: str, msg_prefix: str = ""
+    ) -> None:
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.status_code,
+            200,
+            msg_prefix + f"Expected status code 200, got {response.status_code}.",
+        )
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.headers.get("HX-Redirect"),
+            expected_url,
+            msg_prefix + f"Expected HX-Redirect to '{expected_url}'.",
+        )
+
+    def assertHtmxStopPolling(self, response: Any, msg_prefix: str = "") -> None:
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.status_code,
+            286,
+            msg_prefix + f"Expected HTTP 286, got {response.status_code}.",
+        )

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -1,36 +1,46 @@
 from __future__ import annotations
+
 from typing import Any
+
 from django.test.client import Client
+
+# Maps the short kwarg names a test author would write to the real HX-* headers.
+# Keys match the property names on HtmxDetails so they feel familiar.
+_HTMX_HEADER_MAP = {
+    "boosted": "HTTP_HX_BOOSTED",
+    "current_url": "HTTP_HX_CURRENT_URL",
+    "history_restore_request": "HTTP_HX_HISTORY_RESTORE_REQUEST",
+    "prompt": "HTTP_HX_PROMPT",
+    "target": "HTTP_HX_TARGET",
+    "trigger": "HTTP_HX_TRIGGER",
+    "trigger_name": "HTTP_HX_TRIGGER_NAME",
+}
+
+
+def _build_htmx_headers(htmx: bool | dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {"HTTP_HX_REQUEST": "true"}
+
+    if isinstance(htmx, dict):
+        for key, value in htmx.items():
+            environ_key = _HTMX_HEADER_MAP.get(key)
+            if environ_key is None:
+                raise ValueError(
+                    f"Unknown htmx kwarg {key!r}. "
+                    f"Valid keys are: {sorted(_HTMX_HEADER_MAP)}."
+                )
+            headers[environ_key] = str(value)
+
+    return headers
 
 
 class HtmxClientMixin:
     def request(self, **request: Any) -> Any:
-        request.setdefault("HTTP_HX_REQUEST", "true")
+        htmx = request.pop("htmx", None)
+        if htmx is not None:
+            for key, value in _build_htmx_headers(htmx).items():
+                request.setdefault(key, value)
         return super().request(**request)  # type: ignore [misc]
 
 
 class HtmxClient(HtmxClientMixin, Client):
     pass
-
-
-class HtmxTestCaseAssertions:
-    def assertHtmxClientRedirect(
-        self, response: Any, expected_url: str, msg_prefix: str = ""
-    ) -> None:
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.status_code,
-            200,
-            msg_prefix + f"Expected status code 200, got {response.status_code}.",
-        )
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.headers.get("HX-Redirect"),
-            expected_url,
-            msg_prefix + f"Expected HX-Redirect to '{expected_url}'.",
-        )
-
-    def assertHtmxStopPolling(self, response: Any, msg_prefix: str = "") -> None:
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.status_code,
-            286,
-            msg_prefix + f"Expected HTTP 286, got {response.status_code}.",
-        )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,62 +1,103 @@
 from __future__ import annotations
+
 import json
 from typing import Any
+
 import pytest
 from django.http import HttpResponse
 from django.test import SimpleTestCase, override_settings
 from django.urls import path
-from django_htmx.http import HttpResponseClientRedirect, HttpResponseStopPolling
-from django_htmx.testing import HtmxClient, HtmxTestCaseAssertions
+
+from django_htmx.testing import HtmxClient
 
 
 def echo_view(request: Any) -> HttpResponse:
     return HttpResponse(json.dumps(dict(request.headers)))
+
 urlpatterns = [
     path("echo/", echo_view),
 ]
 
+
 @override_settings(ROOT_URLCONF=__name__)
 class HtmxClientTests(SimpleTestCase):
-    def test_adds_hx_request_header(self):
+    # Basic: htmx=True just sets HX-Request
+    def test_htmx_true_sets_hx_request(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx=True)
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+
+    # Dict form: additional headers get set alongside HX-Request
+    def test_htmx_dict_sets_target(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"target": "#dogs"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "#dogs"
+
+    def test_htmx_dict_sets_trigger(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"trigger": "load"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Trigger") == "load"
+
+    def test_htmx_dict_sets_multiple_headers(self):
+        client = HtmxClient()
+        response = client.get(
+            "/echo/",
+            htmx={"target": "#content", "trigger": "click", "trigger_name": "save-btn"},
+        )
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "#content"
+        assert headers.get("Hx-Trigger") == "click"
+        assert headers.get("Hx-Trigger-Name") == "save-btn"
+
+    def test_htmx_sets_current_url(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"current_url": "http://localhost/dogs/"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Current-Url") == "http://localhost/dogs/"
+
+    def test_htmx_prompt(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"prompt": "are you sure?"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Prompt") == "are you sure?"
+
+    def test_htmx_boosted(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"boosted": "true"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Boosted") == "true"
+
+    def test_htmx_invalid_key_raises(self):
+        client = HtmxClient()
+        with pytest.raises(ValueError, match="Unknown htmx kwarg"):
+            client.get("/echo/", htmx={"typo_key": "bad"})
+
+    # No htmx kwarg at all means a normal non-HTMX request
+    def test_no_htmx_kwarg_is_a_normal_request(self):
         client = HtmxClient()
         response = client.get("/echo/")
+
+        headers = json.loads(response.content)
+        assert "Hx-Request" not in headers
+
+    # Works with POST too, not just GET
+    def test_htmx_works_on_post(self):
+        client = HtmxClient()
+        response = client.post("/echo/", htmx={"target": "#form-result"})
+
         headers = json.loads(response.content)
         assert headers.get("Hx-Request") == "true"
-
-    def test_retains_other_headers(self):
-        client = HtmxClient()
-        response = client.get("/echo/", HTTP_HX_TARGET="the-target")
-        headers = json.loads(response.content)
-        assert headers.get("Hx-Request") == "true"
-        assert headers.get("Hx-Target") == "the-target"
-
-    def test_can_override_hx_request_header(self):
-        client = HtmxClient()
-        response = client.get("/echo/", HTTP_HX_REQUEST="false")
-        headers = json.loads(response.content)
-        assert headers.get("Hx-Request") == "false"
-
-
-class HtmxTestCaseAssertionsTests(SimpleTestCase, HtmxTestCaseAssertions):
-    def test_assert_htmx_client_redirect_success(self):
-        response = HttpResponseClientRedirect("https://example.com")
-        self.assertHtmxClientRedirect(response, "https://example.com")
-
-    def test_assert_htmx_stop_polling_success(self):
-        response = HttpResponseStopPolling()
-        self.assertHtmxStopPolling(response)
-
-    def test_assert_htmx_client_redirect_failure(self):
-        response = HttpResponseClientRedirect("https://example.com")
-        with pytest.raises(AssertionError):
-            self.assertHtmxClientRedirect(response, "https://wrong.com")
-
-    def test_assert_htmx_client_redirect_wrong_status(self):
-        response = HttpResponse(status=404)
-        with pytest.raises(AssertionError):
-            self.assertHtmxClientRedirect(response, "https://example.com")
-
-    def test_assert_htmx_stop_polling_failure(self):
-        response = HttpResponse(status=200)
-        with pytest.raises(AssertionError):
-            self.assertHtmxStopPolling(response)
+        assert headers.get("Hx-Target") == "#form-result"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import json
+from typing import Any
+import pytest
+from django.http import HttpResponse
+from django.test import SimpleTestCase, override_settings
+from django.urls import path
+from django_htmx.http import HttpResponseClientRedirect, HttpResponseStopPolling
+from django_htmx.testing import HtmxClient, HtmxTestCaseAssertions
+
+
+def echo_view(request: Any) -> HttpResponse:
+    return HttpResponse(json.dumps(dict(request.headers)))
+urlpatterns = [
+    path("echo/", echo_view),
+]
+
+@override_settings(ROOT_URLCONF=__name__)
+class HtmxClientTests(SimpleTestCase):
+    def test_adds_hx_request_header(self):
+        client = HtmxClient()
+        response = client.get("/echo/")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+
+    def test_retains_other_headers(self):
+        client = HtmxClient()
+        response = client.get("/echo/", HTTP_HX_TARGET="the-target")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "the-target"
+
+    def test_can_override_hx_request_header(self):
+        client = HtmxClient()
+        response = client.get("/echo/", HTTP_HX_REQUEST="false")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "false"
+
+
+class HtmxTestCaseAssertionsTests(SimpleTestCase, HtmxTestCaseAssertions):
+    def test_assert_htmx_client_redirect_success(self):
+        response = HttpResponseClientRedirect("https://example.com")
+        self.assertHtmxClientRedirect(response, "https://example.com")
+
+    def test_assert_htmx_stop_polling_success(self):
+        response = HttpResponseStopPolling()
+        self.assertHtmxStopPolling(response)
+
+    def test_assert_htmx_client_redirect_failure(self):
+        response = HttpResponseClientRedirect("https://example.com")
+        with pytest.raises(AssertionError):
+            self.assertHtmxClientRedirect(response, "https://wrong.com")
+
+    def test_assert_htmx_client_redirect_wrong_status(self):
+        response = HttpResponse(status=404)
+        with pytest.raises(AssertionError):
+            self.assertHtmxClientRedirect(response, "https://example.com")
+
+    def test_assert_htmx_stop_polling_failure(self):
+        response = HttpResponse(status=200)
+        with pytest.raises(AssertionError):
+            self.assertHtmxStopPolling(response)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -14,6 +14,7 @@ from django_htmx.testing import HtmxClient
 def echo_view(request: Any) -> HttpResponse:
     return HttpResponse(json.dumps(dict(request.headers)))
 
+
 urlpatterns = [
     path("echo/", echo_view),
 ]


### PR DESCRIPTION
Hello,

This PR resolves #583. It introduces an HtmxClient and HtmxTestCaseAssertions inside a new django_htmx.testing module. This eliminates the need for developers to manually build header scaffoldings to mimic HTMX requests.

A dedicated internal Pytest suite has been added and passes entirely.