### PR TITLE
Issue Resolution (#583, #563): Add HtmxClient and automatic Vary: HX-Request middleware.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ This package provides an easy way to include htmx in your Django projects and to
    middleware
    template_tags
    http
+   testing
    example_project
    tips
    changelog

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -11,29 +11,15 @@ Middleware
 
    See it action in the “Middleware Tester” section of the :doc:`example project <example_project>`.
 
-   .. admonition:: Set the ``Vary`` header for cacheable responses
-
-      If you set HTTP caching headers, ensure any views that switch content with ``request.htmx`` attributes add the appropriate htmx headers to the ``Vary`` header, per Django’s documentation section |Using Vary headers|__.
-      For example:
-
-      .. |Using Vary headers| replace:: Using ``Vary`` headers
-      __ https://docs.djangoproject.com/en/stable/topics/cache/#using-vary-headers
-
-      .. code-block:: python
-
-          from django.shortcuts import render
-          from django.views.decorators.cache import cache_control
-          from django.views.decorators.vary import vary_on_headers
-
-
-          @cache_control(max_age=300)
-          @vary_on_headers("HX-Request")
-          def my_view(request):
-              if request.htmx:
-                  template_name = "partial.html"
-              else:
-                  template_name = "complete.html"
-              return render(request, template_name, ...)
+    .. admonition:: Automatic ``Vary`` header
+ 
+       The middleware automatically adds ``HX-Request`` to the ``Vary`` header of all responses.
+       This ensures that browsers and caches correctly distinguish between partial and full page requests for the same URL, preventing "broken" pages when navigating history or using caches.
+ 
+       If you switch content based on other htmx headers (like ``HX-Target``), you should still add those manually using Django’s |Using Vary headers|__.
+ 
+       .. |Using Vary headers| replace:: Using ``Vary`` headers
+       __ https://docs.djangoproject.com/en/stable/topics/cache/#using-vary-headers
 
    .. hint::
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -12,12 +12,12 @@ Middleware
    See it action in the “Middleware Tester” section of the :doc:`example project <example_project>`.
 
     .. admonition:: Automatic ``Vary`` header
- 
+
        The middleware automatically adds ``HX-Request`` to the ``Vary`` header of all responses.
        This ensures that browsers and caches correctly distinguish between partial and full page requests for the same URL, preventing "broken" pages when navigating history or using caches.
- 
+
        If you switch content based on other htmx headers (like ``HX-Target``), you should still add those manually using Django’s |Using Vary headers|__.
- 
+
        .. |Using Vary headers| replace:: Using ``Vary`` headers
        __ https://docs.djangoproject.com/en/stable/topics/cache/#using-vary-headers
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -19,6 +19,7 @@ Testing tools for htmx views.
 
        client = HtmxClient()
 
+
        def test_htmx_view(self):
            response = client.get("/my-view/", htmx=True)
            assert response.status_code == 200

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -3,8 +3,7 @@ Testing
 
 .. currentmodule:: django_htmx.testing
 
-Testing htmx views can be repetitive as they usually switch behaviour based on htmx-specific headers.
-The ``django_htmx.testing`` module provides tools to simplify this.
+Testing tools for htmx views.
 
 .. class:: HtmxClient
 
@@ -21,7 +20,6 @@ The ``django_htmx.testing`` module provides tools to simplify this.
        client = HtmxClient()
 
        def test_htmx_view(self):
-           # Simple htmx request
            response = client.get("/my-view/", htmx=True)
            assert response.status_code == 200
 
@@ -31,7 +29,6 @@ The ``django_htmx.testing`` module provides tools to simplify this.
    .. code-block:: python
 
        def test_htmx_target(self):
-           # Request with a specific target
            response = client.get("/my-view/", htmx={"target": "#info-pane"})
            assert response.status_code == 200
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,55 @@
+Testing
+=======
+
+.. currentmodule:: django_htmx.testing
+
+Testing htmx views can be repetitive as they usually switch behaviour based on htmx-specific headers.
+The ``django_htmx.testing`` module provides tools to simplify this.
+
+.. class:: HtmxClient
+
+   A subclass of Django’s :class:`~django.test.client.Client` that adds an ``htmx`` argument to all request methods (``get()``, ``post()``, etc.).
+
+   When ``htmx`` is set, the client automatically adds htmx-specific headers to the request.
+
+   If ``htmx=True``, the ``HX-Request`` header is set to ``"true"``:
+
+   .. code-block:: python
+
+       from django_htmx.testing import HtmxClient
+
+       client = HtmxClient()
+
+       def test_htmx_view(self):
+           # Simple htmx request
+           response = client.get("/my-view/", htmx=True)
+           assert response.status_code == 200
+
+   If ``htmx`` is a :class:`dict`, the keys are mapped to htmx headers.
+   The ``HX-Request`` header is always set to ``"true"`` in this case:
+
+   .. code-block:: python
+
+       def test_htmx_target(self):
+           # Request with a specific target
+           response = client.get("/my-view/", htmx={"target": "#info-pane"})
+           assert response.status_code == 200
+
+   The following keys are supported in the ``htmx`` dictionary:
+
+   * ``boosted`` (maps to ``HX-Boosted``)
+   * ``current_url`` (maps to ``HX-Current-URL``)
+   * ``history_restore_request`` (maps to ``HX-History-Restore-Request``)
+   * ``prompt`` (maps to ``HX-Prompt``)
+   * ``target`` (maps to ``HX-Target``)
+   * ``trigger`` (maps to ``HX-Trigger``)
+   * ``trigger_name`` (maps to ``HX-Trigger-Name``)
+
+   Passing any other key will raise a :class:`ValueError`.
+
+   Using the client without the ``htmx`` argument (or setting it to ``False`` or ``None``) results in a normal non-htmx request.
+
+.. class:: HtmxClientMixin
+
+   A mixin that can be added to custom client classes to add the ``htmx`` argument support.
+   This is what :class:`HtmxClient` uses internally.

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -37,13 +37,13 @@ class HtmxMiddleware:
         if self.async_mode:
             return self.__acall__(request)
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        response = self.get_response(request)
-        patch_vary_headers(cast(HttpResponseBase, response), ["HX-Request"])
+        response = cast(HttpResponseBase, self.get_response(request))
+        patch_vary_headers(response, ["HX-Request"])
         return response
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        response = await self.get_response(request)  # type: ignore [misc]
+        response = cast(HttpResponseBase, await self.get_response(request))
         patch_vary_headers(response, ["HX-Request"])
         return response
 

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -8,10 +8,8 @@ from urllib.parse import unquote, urlsplit, urlunsplit
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
-from django.utils.functional import cached_property
-
-
 from django.utils.cache import patch_vary_headers
+from django.utils.functional import cached_property
 
 
 class HtmxMiddleware:

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
@@ -38,12 +38,12 @@ class HtmxMiddleware:
             return self.__acall__(request)
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
         response = self.get_response(request)
-        patch_vary_headers(response, ["HX-Request"])
+        patch_vary_headers(cast(HttpResponseBase, response), ["HX-Request"])
         return response
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        response = await self.get_response(request)  # type: ignore [no-any-return, misc]
+        response = await self.get_response(request)  # type: ignore [misc]
         patch_vary_headers(response, ["HX-Request"])
         return response
 

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -11,6 +11,9 @@ from django.http.response import HttpResponseBase
 from django.utils.functional import cached_property
 
 
+from django.utils.cache import patch_vary_headers
+
+
 class HtmxMiddleware:
     sync_capable = True
     async_capable = True
@@ -36,11 +39,15 @@ class HtmxMiddleware:
         if self.async_mode:
             return self.__acall__(request)
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        return self.get_response(request)
+        response = self.get_response(request)
+        patch_vary_headers(response, ["HX-Request"])
+        return response
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        return await self.get_response(request)  # type: ignore [no-any-return, misc]
+        response = await self.get_response(request)  # type: ignore [no-any-return, misc]
+        patch_vary_headers(response, ["HX-Request"])
+        return response
 
 
 class HtmxDetails:

--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -43,7 +43,7 @@ class HtmxMiddleware:
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        response = cast(HttpResponseBase, await self.get_response(request))
+        response = await cast(Awaitable[HttpResponseBase], self.get_response(request))
         patch_vary_headers(response, ["HX-Request"])
         return response
 

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from typing import Any
+from django.test.client import Client
+
+
+class HtmxClientMixin:
+    def request(self, **request: Any) -> Any:
+        request.setdefault("HTTP_HX_REQUEST", "true")
+        return super().request(**request)  # type: ignore [misc]
+
+
+class HtmxClient(HtmxClientMixin, Client):
+    pass
+
+
+class HtmxTestCaseAssertions:
+    def assertHtmxClientRedirect(
+        self, response: Any, expected_url: str, msg_prefix: str = ""
+    ) -> None:
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.status_code,
+            200,
+            msg_prefix + f"Expected status code 200, got {response.status_code}.",
+        )
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.headers.get("HX-Redirect"),
+            expected_url,
+            msg_prefix + f"Expected HX-Redirect to '{expected_url}'.",
+        )
+
+    def assertHtmxStopPolling(self, response: Any, msg_prefix: str = "") -> None:
+        self.assertEqual(  # type: ignore [attr-defined]
+            response.status_code,
+            286,
+            msg_prefix + f"Expected HTTP 286, got {response.status_code}.",
+        )

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -1,36 +1,46 @@
 from __future__ import annotations
+
 from typing import Any
+
 from django.test.client import Client
+
+# Maps the short kwarg names a test author would write to the real HX-* headers.
+# Keys match the property names on HtmxDetails so they feel familiar.
+_HTMX_HEADER_MAP = {
+    "boosted": "HTTP_HX_BOOSTED",
+    "current_url": "HTTP_HX_CURRENT_URL",
+    "history_restore_request": "HTTP_HX_HISTORY_RESTORE_REQUEST",
+    "prompt": "HTTP_HX_PROMPT",
+    "target": "HTTP_HX_TARGET",
+    "trigger": "HTTP_HX_TRIGGER",
+    "trigger_name": "HTTP_HX_TRIGGER_NAME",
+}
+
+
+def _build_htmx_headers(htmx: bool | dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {"HTTP_HX_REQUEST": "true"}
+
+    if isinstance(htmx, dict):
+        for key, value in htmx.items():
+            environ_key = _HTMX_HEADER_MAP.get(key)
+            if environ_key is None:
+                raise ValueError(
+                    f"Unknown htmx kwarg {key!r}. "
+                    f"Valid keys are: {sorted(_HTMX_HEADER_MAP)}."
+                )
+            headers[environ_key] = str(value)
+
+    return headers
 
 
 class HtmxClientMixin:
     def request(self, **request: Any) -> Any:
-        request.setdefault("HTTP_HX_REQUEST", "true")
+        htmx = request.pop("htmx", None)
+        if htmx is not None:
+            for key, value in _build_htmx_headers(htmx).items():
+                request.setdefault(key, value)
         return super().request(**request)  # type: ignore [misc]
 
 
 class HtmxClient(HtmxClientMixin, Client):
     pass
-
-
-class HtmxTestCaseAssertions:
-    def assertHtmxClientRedirect(
-        self, response: Any, expected_url: str, msg_prefix: str = ""
-    ) -> None:
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.status_code,
-            200,
-            msg_prefix + f"Expected status code 200, got {response.status_code}.",
-        )
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.headers.get("HX-Redirect"),
-            expected_url,
-            msg_prefix + f"Expected HX-Redirect to '{expected_url}'.",
-        )
-
-    def assertHtmxStopPolling(self, response: Any, msg_prefix: str = "") -> None:
-        self.assertEqual(  # type: ignore [attr-defined]
-            response.status_code,
-            286,
-            msg_prefix + f"Expected HTTP 286, got {response.status_code}.",
-        )

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -4,8 +4,6 @@ from typing import Any
 
 from django.test.client import Client
 
-# Maps the short kwarg names a test author would write to the real HX-* headers.
-# Keys match the property names on HtmxDetails so they feel familiar.
 _HTMX_HEADER_MAP = {
     "boosted": "HTTP_HX_BOOSTED",
     "current_url": "HTTP_HX_CURRENT_URL",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -177,3 +177,21 @@ class HtmxMiddlewareTests(SimpleTestCase):
 
         assert isinstance(response, HttpResponse)
         assert bool(request.htmx) is True
+
+    def test_vary_header(self):
+        request = self.request_factory.get("/")
+        response = self.middleware(request)
+        assert response.has_header("Vary")
+        assert "HX-Request" in response["Vary"]
+
+    async def test_vary_header_async(self):
+        async def dummy_async_view(request):
+            return HttpResponse("Hello!")
+
+        middleware = HtmxMiddleware(dummy_async_view)
+        request = self.request_factory.get("/")
+        result = middleware(request)
+        response = await result
+
+        assert response.has_header("Vary")
+        assert "HX-Request" in response["Vary"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Awaitable, cast
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
@@ -180,7 +180,7 @@ class HtmxMiddlewareTests(SimpleTestCase):
 
     def test_vary_header(self):
         request = self.request_factory.get("/")
-        response = self.middleware(request)
+        response = cast(HttpResponse, self.middleware(request))
         assert response.has_header("Vary")
         assert "HX-Request" in response["Vary"]
 
@@ -190,7 +190,7 @@ class HtmxMiddlewareTests(SimpleTestCase):
 
         middleware = HtmxMiddleware(dummy_async_view)
         request = self.request_factory.get("/")
-        result = middleware(request)
+        result = cast(Awaitable[HttpResponse], middleware(request))
         response = await result
 
         assert response.has_header("Vary")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Awaitable, cast
+from collections.abc import Awaitable
+from typing import Any, cast
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -22,7 +22,6 @@ urlpatterns = [
 
 @override_settings(ROOT_URLCONF=__name__)
 class HtmxClientTests(SimpleTestCase):
-    # Basic: htmx=True just sets HX-Request
     def test_htmx_true_sets_hx_request(self):
         client = HtmxClient()
         response = client.get("/echo/", htmx=True)
@@ -30,7 +29,6 @@ class HtmxClientTests(SimpleTestCase):
         headers = json.loads(response.content)
         assert headers.get("Hx-Request") == "true"
 
-    # Dict form: additional headers get set alongside HX-Request
     def test_htmx_dict_sets_target(self):
         client = HtmxClient()
         response = client.get("/echo/", htmx={"target": "#dogs"})
@@ -86,7 +84,6 @@ class HtmxClientTests(SimpleTestCase):
         with pytest.raises(ValueError, match="Unknown htmx kwarg"):
             client.get("/echo/", htmx={"typo_key": "bad"})
 
-    # No htmx kwarg at all means a normal non-HTMX request
     def test_no_htmx_kwarg_is_a_normal_request(self):
         client = HtmxClient()
         response = client.get("/echo/")
@@ -94,7 +91,6 @@ class HtmxClientTests(SimpleTestCase):
         headers = json.loads(response.content)
         assert "Hx-Request" not in headers
 
-    # Works with POST too, not just GET
     def test_htmx_works_on_post(self):
         client = HtmxClient()
         response = client.post("/echo/", htmx={"target": "#form-result"})
@@ -102,3 +98,12 @@ class HtmxClientTests(SimpleTestCase):
         headers = json.loads(response.content)
         assert headers.get("Hx-Request") == "true"
         assert headers.get("Hx-Target") == "#form-result"
+
+    @override_settings(
+        MIDDLEWARE=["django_htmx.middleware.HtmxMiddleware"],
+    )
+    def test_with_middleware_includes_vary_header(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx=True)
+        assert response.has_header("Vary")
+        assert "HX-Request" in response["Vary"]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,62 +1,103 @@
 from __future__ import annotations
+
 import json
 from typing import Any
+
 import pytest
 from django.http import HttpResponse
 from django.test import SimpleTestCase, override_settings
 from django.urls import path
-from django_htmx.http import HttpResponseClientRedirect, HttpResponseStopPolling
-from django_htmx.testing import HtmxClient, HtmxTestCaseAssertions
+
+from django_htmx.testing import HtmxClient
 
 
 def echo_view(request: Any) -> HttpResponse:
     return HttpResponse(json.dumps(dict(request.headers)))
+
 urlpatterns = [
     path("echo/", echo_view),
 ]
 
+
 @override_settings(ROOT_URLCONF=__name__)
 class HtmxClientTests(SimpleTestCase):
-    def test_adds_hx_request_header(self):
+    # Basic: htmx=True just sets HX-Request
+    def test_htmx_true_sets_hx_request(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx=True)
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+
+    # Dict form: additional headers get set alongside HX-Request
+    def test_htmx_dict_sets_target(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"target": "#dogs"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "#dogs"
+
+    def test_htmx_dict_sets_trigger(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"trigger": "load"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Trigger") == "load"
+
+    def test_htmx_dict_sets_multiple_headers(self):
+        client = HtmxClient()
+        response = client.get(
+            "/echo/",
+            htmx={"target": "#content", "trigger": "click", "trigger_name": "save-btn"},
+        )
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "#content"
+        assert headers.get("Hx-Trigger") == "click"
+        assert headers.get("Hx-Trigger-Name") == "save-btn"
+
+    def test_htmx_sets_current_url(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"current_url": "http://localhost/dogs/"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Current-Url") == "http://localhost/dogs/"
+
+    def test_htmx_prompt(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"prompt": "are you sure?"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Prompt") == "are you sure?"
+
+    def test_htmx_boosted(self):
+        client = HtmxClient()
+        response = client.get("/echo/", htmx={"boosted": "true"})
+
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Boosted") == "true"
+
+    def test_htmx_invalid_key_raises(self):
+        client = HtmxClient()
+        with pytest.raises(ValueError, match="Unknown htmx kwarg"):
+            client.get("/echo/", htmx={"typo_key": "bad"})
+
+    # No htmx kwarg at all means a normal non-HTMX request
+    def test_no_htmx_kwarg_is_a_normal_request(self):
         client = HtmxClient()
         response = client.get("/echo/")
+
+        headers = json.loads(response.content)
+        assert "Hx-Request" not in headers
+
+    # Works with POST too, not just GET
+    def test_htmx_works_on_post(self):
+        client = HtmxClient()
+        response = client.post("/echo/", htmx={"target": "#form-result"})
+
         headers = json.loads(response.content)
         assert headers.get("Hx-Request") == "true"
-
-    def test_retains_other_headers(self):
-        client = HtmxClient()
-        response = client.get("/echo/", HTTP_HX_TARGET="the-target")
-        headers = json.loads(response.content)
-        assert headers.get("Hx-Request") == "true"
-        assert headers.get("Hx-Target") == "the-target"
-
-    def test_can_override_hx_request_header(self):
-        client = HtmxClient()
-        response = client.get("/echo/", HTTP_HX_REQUEST="false")
-        headers = json.loads(response.content)
-        assert headers.get("Hx-Request") == "false"
-
-
-class HtmxTestCaseAssertionsTests(SimpleTestCase, HtmxTestCaseAssertions):
-    def test_assert_htmx_client_redirect_success(self):
-        response = HttpResponseClientRedirect("https://example.com")
-        self.assertHtmxClientRedirect(response, "https://example.com")
-
-    def test_assert_htmx_stop_polling_success(self):
-        response = HttpResponseStopPolling()
-        self.assertHtmxStopPolling(response)
-
-    def test_assert_htmx_client_redirect_failure(self):
-        response = HttpResponseClientRedirect("https://example.com")
-        with pytest.raises(AssertionError):
-            self.assertHtmxClientRedirect(response, "https://wrong.com")
-
-    def test_assert_htmx_client_redirect_wrong_status(self):
-        response = HttpResponse(status=404)
-        with pytest.raises(AssertionError):
-            self.assertHtmxClientRedirect(response, "https://example.com")
-
-    def test_assert_htmx_stop_polling_failure(self):
-        response = HttpResponse(status=200)
-        with pytest.raises(AssertionError):
-            self.assertHtmxStopPolling(response)
+        assert headers.get("Hx-Target") == "#form-result"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import json
+from typing import Any
+import pytest
+from django.http import HttpResponse
+from django.test import SimpleTestCase, override_settings
+from django.urls import path
+from django_htmx.http import HttpResponseClientRedirect, HttpResponseStopPolling
+from django_htmx.testing import HtmxClient, HtmxTestCaseAssertions
+
+
+def echo_view(request: Any) -> HttpResponse:
+    return HttpResponse(json.dumps(dict(request.headers)))
+urlpatterns = [
+    path("echo/", echo_view),
+]
+
+@override_settings(ROOT_URLCONF=__name__)
+class HtmxClientTests(SimpleTestCase):
+    def test_adds_hx_request_header(self):
+        client = HtmxClient()
+        response = client.get("/echo/")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+
+    def test_retains_other_headers(self):
+        client = HtmxClient()
+        response = client.get("/echo/", HTTP_HX_TARGET="the-target")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "true"
+        assert headers.get("Hx-Target") == "the-target"
+
+    def test_can_override_hx_request_header(self):
+        client = HtmxClient()
+        response = client.get("/echo/", HTTP_HX_REQUEST="false")
+        headers = json.loads(response.content)
+        assert headers.get("Hx-Request") == "false"
+
+
+class HtmxTestCaseAssertionsTests(SimpleTestCase, HtmxTestCaseAssertions):
+    def test_assert_htmx_client_redirect_success(self):
+        response = HttpResponseClientRedirect("https://example.com")
+        self.assertHtmxClientRedirect(response, "https://example.com")
+
+    def test_assert_htmx_stop_polling_success(self):
+        response = HttpResponseStopPolling()
+        self.assertHtmxStopPolling(response)
+
+    def test_assert_htmx_client_redirect_failure(self):
+        response = HttpResponseClientRedirect("https://example.com")
+        with pytest.raises(AssertionError):
+            self.assertHtmxClientRedirect(response, "https://wrong.com")
+
+    def test_assert_htmx_client_redirect_wrong_status(self):
+        response = HttpResponse(status=404)
+        with pytest.raises(AssertionError):
+            self.assertHtmxClientRedirect(response, "https://example.com")
+
+    def test_assert_htmx_stop_polling_failure(self):
+        response = HttpResponse(status=200)
+        with pytest.raises(AssertionError):
+            self.assertHtmxStopPolling(response)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -14,6 +14,7 @@ from django_htmx.testing import HtmxClient
 def echo_view(request: Any) -> HttpResponse:
     return HttpResponse(json.dumps(dict(request.headers)))
 
+
 urlpatterns = [
     path("echo/", echo_view),
 ]


### PR DESCRIPTION
Sorry! while working on the old #589 pr request i accidentlly deleted the branch as wanted to resolve the new #563 issue too. so i have created a mix resolution for both the issue.

as the reason to keep them together as:  The Vary header fix is only 2 lines of code, but it solves a huge production problem. Without it, the HtmxClient is testing a system that is "broken" by default for some users.

1. Testing Utilities (#583): I’ve implemented the HtmxClient using a mixin approach that extends Django’s native Client. As we discussed, I’ve kept the API clean by adding a single htmx keyword argument to the standard request methods (get, post, etc.). This allows for htmx=True for simple triggers or a dictionary for specific headers like target or trigger.

2. Automatic Vary Header (#563): Incorporating the feedback from #563, the HtmxMiddleware now automatically patches the Vary header with HX-Request. This ensures that browsers and downstream caches correctly distinguish between partial and full-page responses, preventing the common "broken partial" bug when using history restoration or hx-boost.

I’ve updated HtmxMiddleware for both synchronous and asynchronous paths. To verify the integration, I've used the new HtmxClient to write tests that confirm the middleware correctly appends the Vary header.

also tested it to run well across the project.

Ready for your review!