### PR TITLE
Add Vary: HX-Request header to middleware responses

### DIFF
--- a/src/django_htmx/middleware.py
+++ b/src/django_htmx/middleware.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
+from django.utils.cache import patch_vary_headers
 from django.utils.functional import cached_property
 
 
@@ -36,11 +37,15 @@ class HtmxMiddleware:
         if self.async_mode:
             return self.__acall__(request)
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        return self.get_response(request)
+        response = cast(HttpResponseBase, self.get_response(request))
+        patch_vary_headers(response, ["HX-Request"])
+        return response
 
     async def __acall__(self, request: HttpRequest) -> HttpResponseBase:
         request.htmx = HtmxDetails(request)  # type: ignore [attr-defined]
-        return await self.get_response(request)  # type: ignore [no-any-return, misc]
+        response = await cast(Awaitable[HttpResponseBase], self.get_response(request))
+        patch_vary_headers(response, ["HX-Request"])
+        return response
 
 
 class HtmxDetails:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -164,6 +164,11 @@ class HtmxMiddlewareTests(SimpleTestCase):
         self.middleware(request)
         assert request.htmx.triggering_event == {"target": None}
 
+    def test_vary_header_sync(self):
+        request = self.request_factory.get("/")
+        response = cast(HttpResponse, self.middleware(request))
+        assert response.headers["Vary"] == "HX-Request"
+
     async def test_async(self):
         async def dummy_async_view(request):
             return HttpResponse("Hello!")
@@ -177,3 +182,16 @@ class HtmxMiddlewareTests(SimpleTestCase):
 
         assert isinstance(response, HttpResponse)
         assert bool(request.htmx) is True
+
+    async def test_vary_header_async(self):
+        async def dummy_async_view(request):
+            return HttpResponse("Hello!")
+
+        middleware = HtmxMiddleware(dummy_async_view)
+        request = self.request_factory.get("/")
+
+        result = middleware(request)
+        assert not isinstance(result, HttpResponseBase)
+        response = await result
+
+        assert response.headers["Vary"] == "HX-Request"


### PR DESCRIPTION
This is the seperate PR solving the #563 issue.