### PR TITLE
Refactor HtmxClient to use modern headers and decouple test views

### DIFF
--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -41,8 +41,7 @@ class HtmxClientMixin:
                     except KeyError:
                         valid_keys = sorted(_HTMX_HEADER_MAP)
                         raise ValueError(
-                            f"Unknown htmx kwarg {key!r}. "
-                            f"Valid keys are: {valid_keys}."
+                            f"Unknown htmx kwarg {key!r}. Valid keys are: {valid_keys}."
                         ) from None
                     headers.setdefault(header_name, str(value))
 

--- a/src/django_htmx/testing.py
+++ b/src/django_htmx/testing.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.test.client import Client
+
+_HTMX_HEADER_MAP = {
+    "boosted": "HX-Boosted",
+    "current_url": "HX-Current-URL",
+    "history_restore_request": "HX-History-Restore-Request",
+    "prompt": "HX-Prompt",
+    "target": "HX-Target",
+    "trigger": "HX-Trigger",
+    "trigger_name": "HX-Trigger-Name",
+}
+
+
+class HtmxClientMixin:
+    def generic(
+        self,
+        method: str,
+        path: str,
+        data: Any = "",
+        content_type: str | None = "application/octet-stream",
+        secure: bool = False,
+        **extra: Any,
+    ) -> Any:
+        htmx = extra.pop("htmx", None)
+        if htmx is not None:
+            headers = extra.get("headers")
+            if headers is None:
+                headers = {}
+                extra["headers"] = headers
+
+            headers.setdefault("HX-Request", "true")
+
+            if isinstance(htmx, dict):
+                for key, value in htmx.items():
+                    try:
+                        header_name = _HTMX_HEADER_MAP[key]
+                    except KeyError:
+                        valid_keys = sorted(_HTMX_HEADER_MAP)
+                        raise ValueError(
+                            f"Unknown htmx kwarg {key!r}. "
+                            f"Valid keys are: {valid_keys}."
+                        ) from None
+                    headers.setdefault(header_name, str(value))
+
+        return super().generic(  # type: ignore [misc]
+            method=method,
+            path=path,
+            data=data,
+            content_type=content_type,
+            secure=secure,
+            **extra,
+        )
+
+
+class HtmxClient(HtmxClientMixin, Client):
+    pass

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -30,7 +30,7 @@ class TemplateTagsTests(SimpleTestCase):
 
 
 def read_version(path: Path, regex: str) -> str:
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     match = re.search(regex, content)
     assert match
     return match[1]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -55,6 +55,7 @@ class HtmxClientTests(SimpleTestCase):
 
     def test_direct_headers(self) -> None:
         from django.test import Client
+
         client = Client()
         response = client.get("/htmx-test/", headers={"HX-Request": "true"})
         data = response.json()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+from django.test import SimpleTestCase, override_settings
+
+from django_htmx.testing import HtmxClient
+
+
+@override_settings(ROOT_URLCONF="tests.urls")
+class HtmxClientTests(SimpleTestCase):
+    client_class = HtmxClient
+
+    def test_get_htmx_true(self) -> None:
+        response = self.client.get("/htmx-test/", htmx=True)
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("Hx-Request") == "true"
+
+    def test_get_htmx_false(self) -> None:
+        response = self.client.get("/htmx-test/", htmx=None)
+        assert response.status_code == 200
+        data = response.json()
+        assert "Hx-Request" not in data
+
+    def test_get_htmx_dict(self) -> None:
+        response = self.client.get(
+            "/htmx-test/",
+            htmx={
+                "boosted": True,
+                "current_url": "https://example.com",
+                "history_restore_request": True,
+                "prompt": "Enter name",
+                "target": "#dogs",
+                "trigger": "click",
+                "trigger_name": "submit-btn",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data.get("Hx-Request") == "true"
+        assert data.get("Hx-Boosted") == "True"
+        assert data.get("Hx-Current-Url") == "https://example.com"
+        assert data.get("Hx-History-Restore-Request") == "True"
+        assert data.get("Hx-Prompt") == "Enter name"
+        assert data.get("Hx-Target") == "#dogs"
+        assert data.get("Hx-Trigger") == "click"
+        assert data.get("Hx-Trigger-Name") == "submit-btn"
+
+    def test_get_htmx_invalid_kwarg(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            self.client.get("/htmx-test/", htmx={"invalid": "value"})
+
+        assert "Unknown htmx kwarg 'invalid'" in str(excinfo.value)
+        assert "Valid keys are: [" in str(excinfo.value)
+
+    def test_direct_headers(self) -> None:
+        from django.test import Client
+        client = Client()
+        response = client.get("/htmx-test/", headers={"HX-Request": "true"})
+        data = response.json()
+        assert data.get("Hx-Request") == "true"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.urls import path
+
 from tests.views import htmx_test_view
 
 urlpatterns = [

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from django.urls import path
+from tests.views import htmx_test_view
+
+urlpatterns = [
+    path("htmx-test/", htmx_test_view),
+]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+
 from django.http import HttpResponse
+
 
 def htmx_test_view(request):
     # Reflect all headers back for verification
-    return HttpResponse(json.dumps(dict(request.headers)), content_type="application/json")
+    return HttpResponse(
+        json.dumps(dict(request.headers)), content_type="application/json"
+    )

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import json
+from django.http import HttpResponse
+
+def htmx_test_view(request):
+    # Reflect all headers back for verification
+    return HttpResponse(json.dumps(dict(request.headers)), content_type="application/json")


### PR DESCRIPTION
Hi, 
I've refactored the HtmxClient as requested. It now uses the modern headers API and the test views/urls have been decoupled.