### PR TITLE
Note :inherited required on htmx 4 in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,3 +60,7 @@ Installation
            ...
          </body>
        </html>
+
+   .. note::
+
+      For htmx version 4, use ``hx-headers:inherited`` instead of ``hx-headers`` on the ``<body>`` tag.


### PR DESCRIPTION
Also add note for checking changes to docs. locally.

If this change makes sense, if not np - note hx-post doesn't work without the ':inherited' addition.