### PR TITLE
Remove sphinx-build-compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -43,8 +42,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
 ]
-if os.environ.get("READTHEDOCS") == "True":
-    extensions.append("sphinx_build_compatibility.extension")
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -71,6 +68,9 @@ html_theme_options = {
         "admonition-font-size": "100%",
         "admonition-title-font-size": "100%",
     },
+    "source_repository": "https://github.com/adamchainz/django-htmx/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 
 # -- Options for LaTeX output ------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ test = [
 docs = [
   "furo>=2024.8.6",
   "sphinx>=7.4.7",
-  "sphinx-build-compatibility",
   "sphinx-copybutton>=0.5.2",
 ]
 django52 = [ "django>=5.2a1,<6; python_version>='3.10'" ]
@@ -66,7 +65,6 @@ example = [
 ]
 
 [tool.uv]
-sources.sphinx-build-compatibility = { git = "https://github.com/readthedocs/sphinx-build-compatibility", rev = "4f304bd4562cdc96316f4fec82b264ca379d23e0" }
 conflicts = [
   [
     { group = "django52" },

--- a/uv.lock
+++ b/uv.lock
@@ -280,9 +280,9 @@ name = "django"
 version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
-    "python_full_version >= '3.12'",
 ]
 dependencies = [
     { name = "asgiref", marker = "python_full_version < '3.12' or extra == 'group-11-django-htmx-django52' or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
@@ -354,7 +354,6 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
-    { name = "sphinx-build-compatibility" },
     { name = "sphinx-copybutton" },
 ]
 example = [
@@ -381,7 +380,6 @@ django61 = [{ name = "django", marker = "python_full_version >= '3.12'", specifi
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "sphinx", specifier = ">=7.4.7" },
-    { name = "sphinx-build-compatibility", git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 example = [
@@ -816,17 +814,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
-]
-
-[[package]]
-name = "sphinx-build-compatibility"
-version = "0.0.1"
-source = { git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0#4f304bd4562cdc96316f4fec82b264ca379d23e0" }
-dependencies = [
-    { name = "requests" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django60') or (extra == 'group-11-django-htmx-django52' and extra == 'group-11-django-htmx-django61') or (extra == 'group-11-django-htmx-django60' and extra == 'group-11-django-htmx-django61')" },
 ]
 
 [[package]]


### PR DESCRIPTION
The extension is [explicitly a temporary workaround](https://github.com/readthedocs/sphinx-build-compatibility) for Read the Docs no longer injecting variables into Sphinx’s html_context. The only ones Furo used were those behind the “edit this page” links, which it supports natively through theme options.
